### PR TITLE
fix: social history conversion

### DIFF
--- a/data/Templates/eCR/Entry/SocialHistory/_entry.liquid
+++ b/data/Templates/eCR/Entry/SocialHistory/_entry.liquid
@@ -14,8 +14,10 @@
                 {% include 'Resource/ObservationPastPresentOccupation' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
             {% when '2.16.840.1.113883.10.20.22.4.221' -%}
                 {% include 'Resource/ObservationUsualWork' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
-            {% when '2.16.840.1.113883.10.20.22.4.38' %}
+            {% when '2.16.840.1.113883.10.20.22.4.38' -%}
                 {% include 'Resource/ObservationSexualOrientation' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
+            {% when '2.16.840.1.113883.10.20.15.3.8' -%}
+                {% include 'Resource/ObservationPregnancyStatus' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
             {% else -%}
                 {% include 'Resource/Observation' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
         {% endcase -%}

--- a/data/Templates/eCR/Entry/SocialHistory/_entry.liquid
+++ b/data/Templates/eCR/Entry/SocialHistory/_entry.liquid
@@ -1,41 +1,29 @@
 {% if entry.observation -%}
-    {% assign observationId = entry.observation | to_json_string | generate_uuid -%}
-    {% if entry.observation.value.nullFlavor and entry.observation.value.originalText == null or entry.observation.code.nullFlavor -%}
-    {% else -%}
-        {% if entry.observation.templateId and entry.observation.templateId.root and entry.observation.templateId.root == '2.16.840.1.113883.10.20.34.3.45' -%}
-        {% elsif entry.observation.templateId and entry.observation.templateId.root and entry.observation.templateId.root == '2.16.840.1.113883.10.20.22.4.200' -%}
-            {% assign birthSObs = entry.observation %}
-        {% elsif entry.observation.templateId and entry.observation.templateId.root and entry.observation.templateId.root == '2.16.840.1.113883.10.20.15.2.3.48' -%}
-        {% else -%}       
-            {% if entry.observation.templateId and entry.observation.templateId.root and entry.observation.templateId.root == '2.16.840.1.113883.10.20.22.4.109' -%}
+    {% capture shouldRender -%}
+        {%- include 'Utils/IsSocialHistoryObservation' observation: entry.observation -%}
+    {%- endcapture -%}
+    {% if shouldRender contains "true" -%}
+        {% assign observationId = entry.observation | to_json_string | generate_uuid -%} 
+        {% assign templateID = entry.observation.templateId.first.root -%}
+        {% case templateId %}
+            {% when '2.16.840.1.113883.10.20.22.4.109' -%}
                 {% include 'Resource/ObservationHomeEnv' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
-                {% include 'Reference/Observation/Subject' ID: observationId, REF: fullPatientId -%}
-            {% elsif entry.observation.templateId and entry.observation.templateId.root and entry.observation.templateId.root == '2.16.840.1.113883.10.20.15.2.3.47' -%}
+            {% when '2.16.840.1.113883.10.20.15.2.3.47' -%}
                 {% include 'Resource/ObservationDisabilityStatus' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
-                {% include 'Reference/Observation/Subject' ID: observationId, REF: fullPatientId -%}
-            {% elsif entry.observation.templateId and entry.observation.templateId.root and entry.observation.templateId.root == '2.16.840.1.113883.10.20.22.4.217' -%}
+            {% when '2.16.840.1.113883.10.20.22.4.217' -%}
                 {% include 'Resource/ObservationPastPresentOccupation' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
-                {% include 'Reference/Observation/Subject' ID: observationId, REF: fullPatientId -%}
-            {% elsif entry.observation.templateId and entry.observation.templateId.root and entry.observation.templateId.root == '2.16.840.1.113883.10.20.22.4.221' -%}
+            {% when '2.16.840.1.113883.10.20.22.4.221' -%}
                 {% include 'Resource/ObservationUsualWork' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
-                {% include 'Reference/Observation/Subject' ID: observationId, REF: fullPatientId -%}
+            {% when '2.16.840.1.113883.10.20.22.4.38' %}
+                {% include 'Resource/ObservationSexualOrientation' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
             {% else -%}
                 {% include 'Resource/Observation' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
-                {% include 'Reference/Observation/Subject' ID: observationId, REF: fullPatientId -%}
-            {% endif -%}
-        {% endif -%}
-    {% endif -%}
+        {% endcase -%}
+        {% include 'Reference/Observation/Subject' ID: observationId, REF: fullPatientId -%}
+    {% endif %}
 {% elsif entry.act %}
     {% assign observationId = entry.act | to_json_string | generate_uuid -%}
     {% if entry.act.templateId and entry.act.templateId.root and entry.act.templateId.root == "2.16.840.1.113883.10.20.15.2.3.1" %}
         {% include 'Resource/ObservationTravelHistory' observationCategory: 'social-history', observationEntry: entry.act, ID: observationId -%}
     {% endif %}
 {% endif -%}
-
-{% for socialObservation in SOCIALOBS -%}
-    {% assign observationId = socialObservation.observation | to_json_string | generate_uuid -%}
-    {% if socialObservation.observation.templateId and socialObservation.observation.templateId[0] and socialObservation.observation.templateId[0].root and socialObservation.observation.templateId[0].root == '2.16.840.1.113883.10.20.22.4.38' and socialObservation.observation.code and socialObservation.observation.code.code == '76690-7' -%}
-        {% include 'Resource/ObservationSexualOrientation' observationCategory: 'social-history', observationEntry: socialObservation.observation, ID: observationId -%},
-        {% include 'Reference/Observation/Subject' ID: observationId, REF: fullPatientId -%}
-    {% endif -%}
-{% endfor -%}

--- a/data/Templates/eCR/Entry/SocialHistory/_entry.liquid
+++ b/data/Templates/eCR/Entry/SocialHistory/_entry.liquid
@@ -4,16 +4,16 @@
     {%- endcapture -%}
     {% if shouldRender contains "true" -%}
         {% assign observationId = entry.observation | to_json_string | generate_uuid -%} 
-        {% assign templateID = entry.observation.templateId.first.root -%}
-        {% if '2.16.840.1.113883.10.20.22.4.109' -%}
+        {% assign firstTemplate = entry.observation.templateId | to_array | first -%}
+        {% if firstTemplate.root == '2.16.840.1.113883.10.20.22.4.109' -%}
             {% include 'Resource/ObservationHomeEnv' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
-        {% elsif templateID == '2.16.840.1.113883.10.20.15.2.3.47' -%}
+        {% elsif firstTemplate.root == '2.16.840.1.113883.10.20.15.2.3.47' -%}
             {% include 'Resource/ObservationDisabilityStatus' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
-        {% elsif templateID == '2.16.840.1.113883.10.20.22.4.217' -%}
+        {% elsif firstTemplate.root == '2.16.840.1.113883.10.20.22.4.217' -%}
             {% include 'Resource/ObservationPastPresentOccupation' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
-        {% elsif templateID == '2.16.840.1.113883.10.20.22.4.221' -%}
+        {% elsif firstTemplate.root == '2.16.840.1.113883.10.20.22.4.221' -%}
             {% include 'Resource/ObservationUsualWork' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
-        {% elsif templateID == '2.16.840.1.113883.10.20.15.3.8' -%}
+        {% elsif firstTemplate.root == '2.16.840.1.113883.10.20.15.3.8' -%}
             {% include 'Resource/ObservationPregnancyStatus' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
         {% elsif entry.observation.code.code == '76690-7' -%}
             {% include 'Resource/ObservationSexualOrientation' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}

--- a/data/Templates/eCR/Entry/SocialHistory/_entry.liquid
+++ b/data/Templates/eCR/Entry/SocialHistory/_entry.liquid
@@ -1,6 +1,6 @@
 {% if entry.observation -%}
     {% assign observationId = entry.observation | to_json_string | generate_uuid -%}
-    {% if entry.observation.code.nullFlavor or entry.observation.value.nullFlavor -%}
+    {% if entry.observation.value.nullFlavor and entry.observation.value.originalText == null or entry.observation.code.nullFlavor -%}
     {% else -%}
         {% if entry.observation.templateId and entry.observation.templateId.root and entry.observation.templateId.root == '2.16.840.1.113883.10.20.34.3.45' -%}
         {% elsif entry.observation.templateId and entry.observation.templateId.root and entry.observation.templateId.root == '2.16.840.1.113883.10.20.22.4.200' -%}

--- a/data/Templates/eCR/Entry/SocialHistory/_entry.liquid
+++ b/data/Templates/eCR/Entry/SocialHistory/_entry.liquid
@@ -5,22 +5,21 @@
     {% if shouldRender contains "true" -%}
         {% assign observationId = entry.observation | to_json_string | generate_uuid -%} 
         {% assign templateID = entry.observation.templateId.first.root -%}
-        {% case templateId %}
-            {% when '2.16.840.1.113883.10.20.22.4.109' -%}
-                {% include 'Resource/ObservationHomeEnv' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
-            {% when '2.16.840.1.113883.10.20.15.2.3.47' -%}
-                {% include 'Resource/ObservationDisabilityStatus' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
-            {% when '2.16.840.1.113883.10.20.22.4.217' -%}
-                {% include 'Resource/ObservationPastPresentOccupation' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
-            {% when '2.16.840.1.113883.10.20.22.4.221' -%}
-                {% include 'Resource/ObservationUsualWork' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
-            {% when '2.16.840.1.113883.10.20.22.4.38' -%}
-                {% include 'Resource/ObservationSexualOrientation' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
-            {% when '2.16.840.1.113883.10.20.15.3.8' -%}
-                {% include 'Resource/ObservationPregnancyStatus' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
-            {% else -%}
-                {% include 'Resource/Observation' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
-        {% endcase -%}
+        {% if '2.16.840.1.113883.10.20.22.4.109' -%}
+            {% include 'Resource/ObservationHomeEnv' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
+        {% elsif templateID == '2.16.840.1.113883.10.20.15.2.3.47' -%}
+            {% include 'Resource/ObservationDisabilityStatus' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
+        {% elsif templateID == '2.16.840.1.113883.10.20.22.4.217' -%}
+            {% include 'Resource/ObservationPastPresentOccupation' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
+        {% elsif templateID == '2.16.840.1.113883.10.20.22.4.221' -%}
+            {% include 'Resource/ObservationUsualWork' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
+        {% elsif templateID == '2.16.840.1.113883.10.20.15.3.8' -%}
+            {% include 'Resource/ObservationPregnancyStatus' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
+        {% elsif entry.observation.code.code == '76690-7' -%}
+            {% include 'Resource/ObservationSexualOrientation' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
+        {% else -%}
+            {% include 'Resource/Observation' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
+        {% endif -%}
         {% include 'Reference/Observation/Subject' ID: observationId, REF: fullPatientId -%}
     {% endif %}
 {% elsif entry.act %}

--- a/data/Templates/eCR/Extension/_BirthSex.liquid
+++ b/data/Templates/eCR/Extension/_BirthSex.liquid
@@ -3,11 +3,7 @@
     "extension" : [
         {
           "url" : "value",
-          "valueCodeableConcept" : {
-            "coding" : [
-              { {% include 'DataType/Coding' Coding: birthSObs.value -%} },
-            ]
-          },
+          {% include 'Utils/ValueHelper' value: birthSobs.value, origText: SOCIALTEXT -%}
         },
       ],
 {% endif -%}

--- a/data/Templates/eCR/Extension/_GenderIdentity.liquid
+++ b/data/Templates/eCR/Extension/_GenderIdentity.liquid
@@ -3,11 +3,7 @@
     "extension" : [
         {
           "url" : "value",
-          "valueCodeableConcept" : {
-            "coding" : [
-              { {% include 'DataType/Coding' Coding: gendIdOb.value -%} },
-            ]
-          },
+          {% include 'Utils/ValueHelper' value: gendIdOb.value, origText: SOCIALTEXT -%}
         },
       ],
 {% endif -%}

--- a/data/Templates/eCR/Extension/_TribalAffiliation.liquid
+++ b/data/Templates/eCR/Extension/_TribalAffiliation.liquid
@@ -9,7 +9,7 @@
         {% if tribeAOb.value -%}
           {
             "url" : "EnrolledTribeMember",
-            "valueBoolean" : {{tribeAOb.value.value}}
+            {% include 'Utils/ValueHelper' value: tribeAOb.value, origText: SOCIALTEXT -%}
           },
         {% endif -%}
       ],

--- a/data/Templates/eCR/Header.liquid
+++ b/data/Templates/eCR/Header.liquid
@@ -137,8 +137,8 @@
 
 {% if msg.ClinicalDocument.recordTarget.patientRole -%}
   {% assign patientSectionObservations = true -%}
-  {% include 'Section/SocialHistory' SOCIALOBS: socialObs -%}
-  {% include 'Resource/Patient' patientRole: msg.ClinicalDocument.recordTarget.patientRole ID: patientId SOCIALOBS: socialObs contact: msg.ClinicalDocument.participant.associatedEntity -%}
+  {% include 'Section/SocialHistory' SOCIALOBS: socialObs SOCIALTEXT: socialHistoryText -%}
+  {% include 'Resource/Patient' patientRole: msg.ClinicalDocument.recordTarget.patientRole ID: patientId SOCIALOBS: socialObs SOCIALTEXT: socialHistoryText contact: msg.ClinicalDocument.participant.associatedEntity -%}
   {% assign careTeam = msg | get_first_ccda_sections_by_template_id: '2.16.840.1.113883.10.20.22.2.500' %} 
   {% if careTeam %}
     {% assign careTeamId = careTeam.2_16_840_1_113883_10_20_22_2_500 | to_json_string | generate_uuid -%}

--- a/data/Templates/eCR/Resource/_Composition.liquid
+++ b/data/Templates/eCR/Resource/_Composition.liquid
@@ -198,14 +198,20 @@
                                 {% assign observationId = sectionEntry.act | to_json_string | generate_uuid -%}
                                 {% assign fullObservationId = observationId | prepend: 'Observation/' -%}
                                 {
-                                    "reference": "{{ fullObservationId }}",
+                                    "reference": "there {{ fullObservationId }}",
                                 },
-                            {% elsif sectionEntry.observation.templateId and sectionEntry.observation.templateId[0] and sectionEntry.observation.templateId[0].root and sectionEntry.observation.templateId[0].root == '2.16.840.1.113883.10.20.22.4.38' and sectionEntry.observation.code and sectionEntry.observation.code.code == '76690-7' -%}
-                                {% assign observationId = sectionEntry.observation | to_json_string | generate_uuid -%}
-                                {% assign fullObservationId = observationId | prepend: 'Observation/' -%}
-                                {
-                                    "reference": "{{ fullObservationId }}",
-                                },
+                            {% elsif component.section.code.code == "29762-2" -%}
+                                {% capture shouldRender -%}
+                                    {%- include 'Utils/IsSocialHistoryObservation' observation: sectionEntry.observation -%}
+                                {%- endcapture -%}
+                                {%- if shouldRender contains "true" -%}
+                                    {% assign observationId = sectionEntry.observation | to_json_string | generate_uuid -%}
+                                    {% assign fullObservationId = observationId | prepend: 'Observation/' -%}
+                                    {
+                                        "reference": "here {{ fullObservationId }}",
+                                        "debug": "{{ sectionEntry.observation.templateId }}"
+                                    },
+                                {% endif -%}
                             {% endif -%}
                         {% endfor -%}
                     ],

--- a/data/Templates/eCR/Resource/_Composition.liquid
+++ b/data/Templates/eCR/Resource/_Composition.liquid
@@ -198,7 +198,7 @@
                                 {% assign observationId = sectionEntry.act | to_json_string | generate_uuid -%}
                                 {% assign fullObservationId = observationId | prepend: 'Observation/' -%}
                                 {
-                                    "reference": "there {{ fullObservationId }}",
+                                    "reference": "{{ fullObservationId }}",
                                 },
                             {% elsif component.section.code.code == "29762-2" -%}
                                 {% capture shouldRender -%}
@@ -208,8 +208,7 @@
                                     {% assign observationId = sectionEntry.observation | to_json_string | generate_uuid -%}
                                     {% assign fullObservationId = observationId | prepend: 'Observation/' -%}
                                     {
-                                        "reference": "here {{ fullObservationId }}",
-                                        "debug": "{{ sectionEntry.observation.templateId }}"
+                                        "reference": "{{ fullObservationId }}",
                                     },
                                 {% endif -%}
                             {% endif -%}

--- a/data/Templates/eCR/Resource/_Condition.liquid
+++ b/data/Templates/eCR/Resource/_Condition.liquid
@@ -65,8 +65,8 @@
                     {% assign templateIdString = relatedEntry.act.templateId.root | to_json_string -%}
                     {% if templateIdString contains '"2.16.840.1.113883.10.20.22.4.64"' or templateIdString contains "2.16.840.1.113883.10.20.22.4.202" and relatedEntry.act.text.reference.value -%}
                         {% assign commentRefVal = relatedEntry.act.text.reference.value | replace: '#', '' -%}
-                        {% assign commentText = text._innerText  | find_inner_text_by_id: commentRefVal -%}
-                        "text": "{{ commentText | clean_strings_from_tabs | escape_special_chars }}",
+                        {% assign commentText = text._innerText | find_inner_text_by_id: commentRefVal -%}
+                        "text": "{{ commentText | clean_string_from_tabs | escape_special_chars }}",
                     {% endif -%}
                 {% endfor -%}
                 

--- a/data/Templates/eCR/Resource/_Condition.liquid
+++ b/data/Templates/eCR/Resource/_Condition.liquid
@@ -66,7 +66,7 @@
                     {% if templateIdString contains '"2.16.840.1.113883.10.20.22.4.64"' or templateIdString contains "2.16.840.1.113883.10.20.22.4.202" and relatedEntry.act.text.reference.value -%}
                         {% assign commentRefVal = relatedEntry.act.text.reference.value | replace: '#', '' -%}
                         {% assign commentText = text._innerText  | find_inner_text_by_id: commentRefVal -%}
-                        "text": "{{ commentText | escape_special_chars }}",
+                        "text": "{{ commentText | clean_strings_from_tabs | escape_special_chars }}",
                     {% endif -%}
                 {% endfor -%}
                 

--- a/data/Templates/eCR/Resource/_Observation.liquid
+++ b/data/Templates/eCR/Resource/_Observation.liquid
@@ -1,5 +1,6 @@
 {
     "fullUrl":"urn:uuid:{{ ID }}",
+        {{ observationEntry | print_object }}
     "resource":{
         "resourceType": "Observation",
         "id":"{{ ID }}",
@@ -72,16 +73,10 @@
             {% if observationEntry.value._ %}
                 "valueString":"{{ observationEntry.value._ }}",
             {% else %}
-                {% assign obsRefVal = observationEntry.value.reference.value | replace: '#', '' -%}
-                {% assign valueStringObject = text | find_object_by_id: obsRefVal -%}
-                {% if valueStringObject != null %}
-                        {% if valueStringObject._ != null %}
-                            {% assign valueString = valueStringObject._ | concat_strings %}
-                        {% elsif valueStringObject.content != null %}
-                            {% assign valueString = valueStringObject.content | concat_strings %}
-                        {% endif %}
-                    "valueString": "{{ valueString | replace: '\n', '\\n'  }}",
-                {% endif %}
+                {% assign obsRef = observationEntry.value.reference.value | default: observationEntry.value.originalText.reference.value -%}
+                {% assign obsRefVal = obsRef | replace: '#', '' -%}
+                {% assign valueString = text._innerText | find_inner_text_by_id: obsRefVal -%}
+                "valueString": "{{ valueString | escape_special_chars }}",
             {% endif %}
         {% endif -%}
         "referenceRange":

--- a/data/Templates/eCR/Resource/_Observation.liquid
+++ b/data/Templates/eCR/Resource/_Observation.liquid
@@ -1,6 +1,5 @@
 {
     "fullUrl":"urn:uuid:{{ ID }}",
-        {{ observationEntry | print_object }}
     "resource":{
         "resourceType": "Observation",
         "id":"{{ ID }}",

--- a/data/Templates/eCR/Resource/_Observation.liquid
+++ b/data/Templates/eCR/Resource/_Observation.liquid
@@ -75,7 +75,7 @@
                 {% assign obsRef = observationEntry.value.reference.value | default: observationEntry.value.originalText.reference.value -%}
                 {% assign obsRefVal = obsRef | replace: '#', '' -%}
                 {% assign valueString = text._innerText | find_inner_text_by_id: obsRefVal -%}
-                "valueString": "{{ valueString | escape_special_chars }}",
+                "valueString": "{{ valueString | clean_string_from_tabs | escape_special_chars }}",
             {% endif %}
         {% endif -%}
         "referenceRange":

--- a/data/Templates/eCR/Resource/_Observation.liquid
+++ b/data/Templates/eCR/Resource/_Observation.liquid
@@ -55,29 +55,7 @@
         {
             {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.targetSiteCode -%}
         },
-        {% if observationEntry.value.code -%}
-            "valueCodeableConcept":
-            {
-                {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.value -%}
-            },
-        {% elsif observationEntry.value.value -%}
-            "valueQuantity":
-            {
-                "value":{{ observationEntry.value.value }},
-                {% if observationEntry.value.unit and  observationEntry.value.unit != "null" -%}
-                "unit":"{{ observationEntry.value.unit }}",
-                {% endif -%}
-            },
-        {% else -%}
-            {% if observationEntry.value._ %}
-                "valueString":"{{ observationEntry.value._ }}",
-            {% else %}
-                {% assign obsRef = observationEntry.value.reference.value | default: observationEntry.value.originalText.reference.value -%}
-                {% assign obsRefVal = obsRef | replace: '#', '' -%}
-                {% assign valueString = text._innerText | find_inner_text_by_id: obsRefVal -%}
-                "valueString": "{{ valueString | clean_string_from_tabs | escape_special_chars }}",
-            {% endif %}
-        {% endif -%}
+        {% include 'Utils/ValueHelper' node: observationEntry, origText: text._innerText %}
         "referenceRange":
         [
             {

--- a/data/Templates/eCR/Resource/_Observation.liquid
+++ b/data/Templates/eCR/Resource/_Observation.liquid
@@ -55,7 +55,7 @@
         {
             {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.targetSiteCode -%}
         },
-        {% include 'Utils/ValueHelper' node: observationEntry, origText: text._innerText %}
+        {% include 'Utils/ValueHelper' value: observationEntry.value, origText: text._innerText %}
         "referenceRange":
         [
             {

--- a/data/Templates/eCR/Resource/_ObservationDisabilityStatus.liquid
+++ b/data/Templates/eCR/Resource/_ObservationDisabilityStatus.liquid
@@ -53,14 +53,7 @@
         {% if observationEntry.effectiveTime.low.value == null -%}
         "effectiveDateTime":"{{ observationEntry.effectiveTime.value | format_as_date_time }}",
         {% endif -%}
-        {% if observationEntry.value.code -%}
-            "valueCodeableConcept":
-            {
-                {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.value -%}
-            },
-        {% elsif observationEntry.value.value -%}
-            "valueBoolean": {{ observationEntry.value.value }},
-        {% endif -%}
+        {% include 'Utils/ValueHelper' value: observationEntry.value, origText: text._innerText -%}
     },
     "request":{
         "method":"PUT",

--- a/data/Templates/eCR/Resource/_ObservationHomeEnv.liquid
+++ b/data/Templates/eCR/Resource/_ObservationHomeEnv.liquid
@@ -53,20 +53,7 @@
         {% if observationEntry.effectiveTime.low.value == null -%}
         "effectiveDateTime":"{{ observationEntry.effectiveTime.value | format_as_date_time }}",
         {% endif -%}
-        {% if observationEntry.value.code -%}
-            "valueCodeableConcept":
-            {
-                {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.value -%}
-            },
-        {% elsif observationEntry.value.value -%}
-            "valueQuantity":
-            {
-                "value":{{ observationEntry.value.value }},
-                "unit":"{{ observationEntry.value.unit }}",
-            },
-        {% else -%}
-            "valueString":"{{ observationEntry.value._ }}",
-        {% endif -%}
+        {% include 'Utils/ValueHelper' value: observationEntry.value, origText: text._innerText %}
     },
     "request":{
         "method":"PUT",

--- a/data/Templates/eCR/Resource/_ObservationPastPresentOccupation.liquid
+++ b/data/Templates/eCR/Resource/_ObservationPastPresentOccupation.liquid
@@ -58,26 +58,7 @@
         {% if observationEntry.effectiveTime.low.value == null -%}
         "effectiveDateTime":"{{ observationEntry.effectiveTime.value | format_as_date_time }}",
         {% endif -%}
-        {% if observationEntry.value.code -%}
-            "valueCodeableConcept":
-            {
-                {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.value -%},
-                {% assign obsValueTrans = observationEntry.value.translation | to_array -%}
-                    {% if obsValueTrans.first -%}
-                        {% for obsValueTran in obsValueTrans -%}
-                            {% include 'DataType/CodeableConcept' CodeableConcept: obsValueTran -%},
-                        {% endfor -%}
-                    {% endif -%}
-            },
-        {% elsif observationEntry.value.value -%}
-            "valueQuantity":
-            {
-                "value":{{ observationEntry.value.value }},
-                "unit":"{{ observationEntry.value.unit }}",
-            },
-        {% else -%}
-            "valueString":"{{ observationEntry.value._ }}",
-        {% endif -%}
+        {% include 'Utils/ValueHelper' value: observationEntry.value, origText: text._innerText -%}
         "component" : [
             {% assign obsRelationships = observationEntry.entryRelationship | to_array -%}
             {% for obsRelation in obsRelationships -%}
@@ -91,26 +72,7 @@
                             {% include 'DataType/CodeableConcept' CodeableConcept: obsRelation.observation.code -%}
                         {% endif -%}
                     },
-                {% if obsRelation.observation.value.code -%}
-                    "valueCodeableConcept":
-                    {
-                        {% include 'DataType/CodeableConcept' CodeableConcept: obsRelation.observation.value -%},
-                        {% assign obsValueTransRel = obsRelation.observation.value.translation | to_array -%}
-                            {% if obsValueTransRel.first -%}
-                                {% for obsValueTranRel in obsValueTransRel -%}
-                                    {% include 'DataType/CodeableConcept' CodeableConcept: obsValueTranRel -%},
-                                {% endfor -%}
-                            {% endif -%}
-                    },
-                {% elsif obsRelation.observation.value.value -%}
-                    "valueQuantity":
-                    {
-                        "value":{{ obsRelation.observation.value.value }},
-                        "unit":"{{ obsRelation.observation.value.unit }}",
-                    },
-                {% else -%}
-                    "valueString":"{{ obsRelation.observation.value._ }}",
-                {% endif -%}
+                {% include 'Utils/ValueHelper' value: obsRelation.observation.value, origText: text._innerText -%}
             },
             {% endfor -%}
         ],

--- a/data/Templates/eCR/Resource/_ObservationPregnancyStatus.liquid
+++ b/data/Templates/eCR/Resource/_ObservationPregnancyStatus.liquid
@@ -58,26 +58,7 @@
         {% if observationEntry.effectiveTime.low.value == null -%}
         "effectiveDateTime":"{{ observationEntry.effectiveTime.value | format_as_date_time }}",
         {% endif -%}
-        {% if observationEntry.value.code -%}
-            "valueCodeableConcept":
-            {
-                {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.value -%},
-                {% assign obsValueTrans = observationEntry.value.translation | to_array -%}
-                    {% if obsValueTrans.first -%}
-                        {% for obsValueTran in obsValueTrans -%}
-                            {% include 'DataType/CodeableConcept' CodeableConcept: obsValueTran -%},
-                        {% endfor -%}
-                    {% endif -%}
-            },
-        {% elsif observationEntry.value.value -%}
-            "valueQuantity":
-            {
-                "value":{{ observationEntry.value.value }},
-                "unit":"{{ observationEntry.value.unit }}",
-            },
-        {% else -%}
-            "valueString":"{{ observationEntry.value._ }}",
-        {% endif -%}
+        {% include 'Utils/ValueHelper' value: observationEntry.value, origText: text._innerText -%}
         "component" : [
             {% assign obsRelationships = observationEntry.entryRelationship | to_array -%}
             {% for obsRelation in obsRelationships -%}
@@ -91,26 +72,7 @@
                             {% include 'DataType/CodeableConcept' CodeableConcept: obsRelation.observation.code -%}
                         {% endif -%}
                     },
-                {% if obsRelation.observation.value.code -%}
-                    "valueCodeableConcept":
-                    {
-                        {% include 'DataType/CodeableConcept' CodeableConcept: obsRelation.observation.value -%},
-                        {% assign obsValueTransRel = obsRelation.observation.value.translation | to_array -%}
-                            {% if obsValueTransRel.first -%}
-                                {% for obsValueTranRel in obsValueTransRel -%}
-                                    {% include 'DataType/CodeableConcept' CodeableConcept: obsValueTranRel -%},
-                                {% endfor -%}
-                            {% endif -%}
-                    },
-                {% elsif obsRelation.observation.value.value -%}
-                    "valueQuantity":
-                    {
-                        "value":{{ obsRelation.observation.value.value }},
-                        "unit":"{{ obsRelation.observation.value.unit }}",
-                    },
-                {% else -%}
-                    "valueString":"{{ obsRelation.observation.value._ }}",
-                {% endif -%}
+                {% include 'Utils/ValueHelper' value: obsRelation.observation.value, origText: text._innerText -%}
             },
             {% endfor -%}
         ],

--- a/data/Templates/eCR/Resource/_ObservationRRCondition.liquid
+++ b/data/Templates/eCR/Resource/_ObservationRRCondition.liquid
@@ -70,20 +70,7 @@
         {
             {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.targetSiteCode -%}
         },
-        {% if observationEntry.value.code -%}
-            "valueCodeableConcept":
-            {
-                {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.value -%}
-            },
-        {% elsif observationEntry.value.value -%}
-            "valueQuantity":
-            {
-                "value":{{ observationEntry.value.value }},
-                "unit":"{{ observationEntry.value.unit }}",
-            },
-        {% else -%}
-            "valueString":"{{ observationEntry.value._ }}",
-        {% endif -%}
+        {% include 'Utils/ValueHelper' value: observationEntry.value, origText: text._innerText -%}
         "referenceRange":
         [
             {

--- a/data/Templates/eCR/Resource/_ObservationSexualOrientation.liquid
+++ b/data/Templates/eCR/Resource/_ObservationSexualOrientation.liquid
@@ -41,28 +41,7 @@
         {% endif -%}
         {% comment %} When we have eCRs with actual data for this element, revist these values {% endcomment %}
         {% comment %} May need to use this ValueSet: http://hl7.org/fhir/us/core/STU6.1/ValueSet-us-core-sexual-orientation.html {% endcomment %}
-        {% if observationEntry.value.code -%}
-            "valueCodeableConcept":
-            {
-                {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.value -%},
-                {% assign obsValueTrans = observationEntry.value.translation | to_array -%}
-                    {% if obsValueTrans.first -%}
-                        {% for obsValueTran in obsValueTrans -%}
-                            {% include 'DataType/CodeableConcept' CodeableConcept: obsValueTran -%},
-                        {% endfor -%}
-                    {% endif -%}
-            },
-        {% elsif observationEntry.value.value -%}
-            "valueQuantity":
-            {
-                "value":{{ observationEntry.value.value }},
-                "unit":"{{ observationEntry.value.unit }}",
-            },
-        {% elsif observationEntry.value.originalText.reference._ -%}
-            "valueString":"{{ observationEntry.value.originalText.reference._ }}",
-        {% else -%}
-            "valueString":"unknown",
-        {% endif -%}
+        {% include 'Utils/ValueHelper' value: observationEntry.value, origText: text._innerText -%}
     },
     "request":{
         "method":"PUT",

--- a/data/Templates/eCR/Resource/_ObservationTravelHistory.liquid
+++ b/data/Templates/eCR/Resource/_ObservationTravelHistory.liquid
@@ -57,26 +57,7 @@
         {% if observationEntry.effectiveTime.low.value == null -%}
         "effectiveDateTime":"{{ observationEntry.effectiveTime.value | format_as_date_time }}",
         {% endif -%}
-        {% if observationEntry.value.code -%}
-            "valueCodeableConcept":
-            {
-                {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.value -%},
-                {% assign obsValueTrans = observationEntry.value.translation | to_array -%}
-                    {% if obsValueTrans.first -%}
-                        {% for obsValueTran in obsValueTrans -%}
-                            {% include 'DataType/CodeableConcept' CodeableConcept: obsValueTran -%},
-                        {% endfor -%}
-                    {% endif -%}
-            },
-        {% elsif observationEntry.value.value -%}
-            "valueQuantity":
-            {
-                "value":{{ observationEntry.value.value }},
-                "unit":"{{ observationEntry.value.unit }}",
-            },
-        {% else -%}
-            "valueString":"{{ observationEntry.value._ }}",
-        {% endif -%}
+        {% include 'Utils/ValueHelper' value: observationEntry.value, origText: text._innerText -%}
     },
     "request":{
         "method":"PUT",

--- a/data/Templates/eCR/Resource/_ObservationUsualWork.liquid
+++ b/data/Templates/eCR/Resource/_ObservationUsualWork.liquid
@@ -58,26 +58,7 @@
         {% if observationEntry.effectiveTime.low.value == null -%}
         "effectiveDateTime":"{{ observationEntry.effectiveTime.value | format_as_date_time }}",
         {% endif -%}
-        {% if observationEntry.value.code -%}
-            "valueCodeableConcept":
-            {
-                {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.value -%},
-                {% assign obsValueTrans = observationEntry.value.translation | to_array -%}
-                    {% if obsValueTrans.first -%}
-                        {% for obsValueTran in obsValueTrans -%}
-                            {% include 'DataType/CodeableConcept' CodeableConcept: obsValueTran -%},
-                        {% endfor -%}
-                    {% endif -%}
-            },
-        {% elsif observationEntry.value.value -%}
-            "valueQuantity":
-            {
-                "value":{{ observationEntry.value.value }},
-                "unit":"{{ observationEntry.value.unit }}",
-            },
-        {% else -%}
-            "valueString":"{{ observationEntry.value._ }}",
-        {% endif -%}
+        {% include 'Utils/ValueHelper' value: observationEntry.value, origText: text._innerText -%}
         "component" : [
             {% assign obsRelationships = observationEntry.entryRelationship | to_array -%}
             {% for obsRelation in obsRelationships -%}
@@ -91,26 +72,7 @@
                             {% include 'DataType/CodeableConcept' CodeableConcept: obsRelation.observation.code -%}
                         {% endif -%}
                     },
-                {% if obsRelation.observation.value.code -%}
-                    "valueCodeableConcept":
-                    {
-                        {% include 'DataType/CodeableConcept' CodeableConcept: obsRelation.observation.value -%},
-                        {% assign obsValueTransRel = obsRelation.observation.value.translation | to_array -%}
-                            {% if obsValueTransRel.first -%}
-                                {% for obsValueTranRel in obsValueTransRel -%}
-                                    {% include 'DataType/CodeableConcept' CodeableConcept: obsValueTranRel -%},
-                                {% endfor -%}
-                            {% endif -%}
-                    },
-                {% elsif obsRelation.observation.value.value -%}
-                    "valueQuantity":
-                    {
-                        "value":{{ obsRelation.observation.value.value }},
-                        "unit":"{{ obsRelation.observation.value.unit }}",
-                    },
-                {% else -%}
-                    "valueString":"{{ obsRelation.observation.value._ }}",
-                {% endif -%}
+                {% include 'Utils/ValueHelper' value: obsRelation.observation.value, origText: text._innerText -%}
             },
             {% endfor -%}
         ],

--- a/data/Templates/eCR/Resource/_Patient.liquid
+++ b/data/Templates/eCR/Resource/_Patient.liquid
@@ -40,9 +40,9 @@
                 {% assign firstTemplate = entry.observation.templateId | to_array | first -%}
                 {% if firstTemplate.root == '2.16.840.1.113883.10.20.34.3.45' or entry.observation.code.code == '76691-5' -%}
                     { {% include 'Extension/GenderIdentity' gendIdOb: entry.observation -%} },
-                {% if firstTemplate.root == '2.16.840.1.113883.10.20.15.2.3.48' -%}
+                {% elsif firstTemplate.root == '2.16.840.1.113883.10.20.15.2.3.48' -%}
                     { {% include 'Extension/TribalAffiliation' tribeAOb: entry.observation -%} },
-                {% if firstTemplate.root == '2.16.840.1.113883.10.20.22.4.200' -%}
+                {% elsif firstTemplate.root == '2.16.840.1.113883.10.20.22.4.200' -%}
                      { {% include 'Extension/BirthSex' birthSObs: entry.observation -%} },
                 {% endif -%}
             {% endfor -%}

--- a/data/Templates/eCR/Resource/_Patient.liquid
+++ b/data/Templates/eCR/Resource/_Patient.liquid
@@ -37,8 +37,8 @@
             { {% include 'Extension/Race' Race: patientRole.patient -%} },
             { {% include 'Extension/Ethnicity' Ethnicity: patientRole.patient -%} },
             {% for entry in SOCIALOBS -%}
-                {% assign templateId = entry.observation.templateId.first.root -%}
-                {% case templateId -%}
+                {% assign firstTemplate = entry.observation.templateId | to_array | first -%}
+                {% case firstTemplate.root -%}
                 {% when '2.16.840.1.113883.10.20.34.3.45' -%}
                     { {% include 'Extension/GenderIdentity' gendIdOb: entry.observation -%} },
                 {% when '2.16.840.1.113883.10.20.15.2.3.48' -%}

--- a/data/Templates/eCR/Resource/_Patient.liquid
+++ b/data/Templates/eCR/Resource/_Patient.liquid
@@ -38,14 +38,13 @@
             { {% include 'Extension/Ethnicity' Ethnicity: patientRole.patient -%} },
             {% for entry in SOCIALOBS -%}
                 {% assign firstTemplate = entry.observation.templateId | to_array | first -%}
-                {% case firstTemplate.root -%}
-                {% when '2.16.840.1.113883.10.20.34.3.45' -%}
+                {% if firstTemplate.root == '2.16.840.1.113883.10.20.34.3.45' or entry.observation.code.code == '76691-5' -%}
                     { {% include 'Extension/GenderIdentity' gendIdOb: entry.observation -%} },
-                {% when '2.16.840.1.113883.10.20.15.2.3.48' -%}
+                {% if firstTemplate.root == '2.16.840.1.113883.10.20.15.2.3.48' -%}
                     { {% include 'Extension/TribalAffiliation' tribeAOb: entry.observation -%} },
-                {% when '2.16.840.1.113883.10.20.22.4.200' -%}
+                {% if firstTemplate.root == '2.16.840.1.113883.10.20.22.4.200' -%}
                      { {% include 'Extension/BirthSex' birthSObs: entry.observation -%} },
-                {% endcase -%}
+                {% endif -%}
             {% endfor -%}
 
         ],

--- a/data/Templates/eCR/Resource/_Patient.liquid
+++ b/data/Templates/eCR/Resource/_Patient.liquid
@@ -36,14 +36,16 @@
         [
             { {% include 'Extension/Race' Race: patientRole.patient -%} },
             { {% include 'Extension/Ethnicity' Ethnicity: patientRole.patient -%} },
-            {% for socialObservation in SOCIALOBS -%}
-                {% if socialObservation.observation.templateId and socialObservation.observation.templateId.root and socialObservation.observation.templateId.root == '2.16.840.1.113883.10.20.34.3.45' -%}
-                    { {% include 'Extension/GenderIdentity' gendIdOb: socialObservation.observation -%} },
-                {% elsif socialObservation.observation.templateId and socialObservation.observation.templateId.root and socialObservation.observation.templateId.root == '2.16.840.1.113883.10.20.15.2.3.48' -%}
-                    { {% include 'Extension/TribalAffiliation' tribeAOb: socialObservation.observation -%} },
-                {% elsif socialObservation.observation.templateId and socialObservation.observation.templateId.root and socialObservation.observation.templateId.root == '2.16.840.1.113883.10.20.22.4.200' -%}
-                     { {% include 'Extension/BirthSex' birthSObs: socialObservation.observation -%} },
-                {% endif -%}
+            {% for entry in SOCIALOBS -%}
+                {% assign templateId = entry.observation.templateId.first.root -%}
+                {% case templateId -%}
+                {% when '2.16.840.1.113883.10.20.34.3.45' -%}
+                    { {% include 'Extension/GenderIdentity' gendIdOb: entry.observation -%} },
+                {% when '2.16.840.1.113883.10.20.15.2.3.48' -%}
+                    { {% include 'Extension/TribalAffiliation' tribeAOb: entry.observation -%} },
+                {% when '2.16.840.1.113883.10.20.22.4.200' -%}
+                     { {% include 'Extension/BirthSex' birthSObs: entry.observation -%} },
+                {% endcase -%}
             {% endfor -%}
 
         ],

--- a/data/Templates/eCR/Section/_SocialHistory.liquid
+++ b/data/Templates/eCR/Section/_SocialHistory.liquid
@@ -1,7 +1,8 @@
 {% assign firstSections = msg | get_first_ccda_sections_by_template_id: '2.16.840.1.113883.10.20.22.2.17' -%}
+    {% assign text = firstSections.2_16_840_1_113883_10_20_22_2_17.text -%}
+    {% assign socialHistoryText = text._innerText -%}
     {% if patientSectionObservations -%}
         {% assign socialObs = firstSections.2_16_840_1_113883_10_20_22_2_17.entry | to_array -%}
     {% else -%}
-        {% assign text = firstSections.2_16_840_1_113883_10_20_22_2_17.text -%}
         {{ firstSections.2_16_840_1_113883_10_20_22_2_17.entry | to_array | batch_render: 'Entry/SocialHistory/entry', 'entry' }}
     {% endif -%}

--- a/data/Templates/eCR/Section/_SocialHistory.liquid
+++ b/data/Templates/eCR/Section/_SocialHistory.liquid
@@ -2,5 +2,6 @@
     {% if patientSectionObservations -%}
         {% assign socialObs = firstSections.2_16_840_1_113883_10_20_22_2_17.entry | to_array -%}
     {% else -%}
+        {% assign text = firstSections.2_16_840_1_113883_10_20_22_2_17.text -%}
         {{ firstSections.2_16_840_1_113883_10_20_22_2_17.entry | to_array | batch_render: 'Entry/SocialHistory/entry', 'entry' }}
     {% endif -%}

--- a/data/Templates/eCR/Utils/_IsSocialHistoryObservation.liquid
+++ b/data/Templates/eCR/Utils/_IsSocialHistoryObservation.liquid
@@ -1,9 +1,10 @@
 {% assign result = false -%}
+{% assign rootTemplateId = observation.templateId.first.root -%}
 {% if observation.value.nullFlavor and observation.value.originalText == null or observation.code.nullFlavor -%}
-{% elsif observation.templateId.root == '2.16.840.1.113883.10.20.34.3.45' -%}
-{% elsif observation.templateId.root == '2.16.840.1.113883.10.20.22.4.200' -%}
+{% elsif rootTemplateId == '2.16.840.1.113883.10.20.34.3.45' -%}
+{% elsif rootTemplateId == '2.16.840.1.113883.10.20.22.4.200' -%}
 {% comment -%} Birth sex handled by the patient template {% endcomment -%}
-{% elsif observation.templateId.root == '2.16.840.1.113883.10.20.15.2.3.48' -%}    
+{% elsif rootTemplateId == '2.16.840.1.113883.10.20.15.2.3.48' -%}    
 {% else -%}
     {% assign result = true -%}
 {% endif -%}

--- a/data/Templates/eCR/Utils/_IsSocialHistoryObservation.liquid
+++ b/data/Templates/eCR/Utils/_IsSocialHistoryObservation.liquid
@@ -1,10 +1,13 @@
 {% assign result = false -%}
 {% assign firstTemplate = observation.templateId | to_array | first -%}
 {% if observation.value.nullFlavor and observation.value.originalText == null or observation.code.nullFlavor -%}
-{% elsif firstTemplate.root == '2.16.840.1.113883.10.20.34.3.45' -%}
+{% comment -%} ^ Don't include truly unknown observations {% endcomment -%}
+{% elsif firstTemplate.root == '2.16.840.1.113883.10.20.34.3.45' or observation.code.code == '76691-5' -%}
+{% comment -%} ^ Gender Identity handled as an extension to patient{% endcomment -%}
 {% elsif firstTemplate.root == '2.16.840.1.113883.10.20.22.4.200' -%}
-{% comment -%} Birth sex handled by the patient template {% endcomment -%}
+{% comment -%} ^ Birth sex handled as extension to patient {% endcomment -%}
 {% elsif firstTemplate.root == '2.16.840.1.113883.10.20.15.2.3.48' -%}    
+{% comment -%} ^ Tribal Affiliation handled as an extension to patient{% endcomment -%}
 {% else -%}
     {% assign result = true -%}
 {% endif -%}

--- a/data/Templates/eCR/Utils/_IsSocialHistoryObservation.liquid
+++ b/data/Templates/eCR/Utils/_IsSocialHistoryObservation.liquid
@@ -1,0 +1,10 @@
+{% assign result = false -%}
+{% if observation.value.nullFlavor and observation.value.originalText == null or observation.code.nullFlavor -%}
+{% elsif observation.templateId.root == '2.16.840.1.113883.10.20.34.3.45' -%}
+{% elsif observation.templateId.root == '2.16.840.1.113883.10.20.22.4.200' -%}
+{% comment -%} Birth sex handled by the patient template {% endcomment -%}
+{% elsif observation.templateId.root == '2.16.840.1.113883.10.20.15.2.3.48' -%}    
+{% else -%}
+    {% assign result = true -%}
+{% endif -%}
+{{ result }}

--- a/data/Templates/eCR/Utils/_IsSocialHistoryObservation.liquid
+++ b/data/Templates/eCR/Utils/_IsSocialHistoryObservation.liquid
@@ -1,10 +1,10 @@
 {% assign result = false -%}
-{% assign rootTemplateId = observation.templateId.first.root -%}
+{% assign firstTemplate = observation.templateId | to_array | first -%}
 {% if observation.value.nullFlavor and observation.value.originalText == null or observation.code.nullFlavor -%}
-{% elsif rootTemplateId == '2.16.840.1.113883.10.20.34.3.45' -%}
-{% elsif rootTemplateId == '2.16.840.1.113883.10.20.22.4.200' -%}
+{% elsif firstTemplate.root == '2.16.840.1.113883.10.20.34.3.45' -%}
+{% elsif firstTemplate.root == '2.16.840.1.113883.10.20.22.4.200' -%}
 {% comment -%} Birth sex handled by the patient template {% endcomment -%}
-{% elsif rootTemplateId == '2.16.840.1.113883.10.20.15.2.3.48' -%}    
+{% elsif firstTemplate.root == '2.16.840.1.113883.10.20.15.2.3.48' -%}    
 {% else -%}
     {% assign result = true -%}
 {% endif -%}

--- a/data/Templates/eCR/Utils/_ValueHelper.liquid
+++ b/data/Templates/eCR/Utils/_ValueHelper.liquid
@@ -1,0 +1,26 @@
+{% if value.code %}
+    "valueCodeableConcept" : {
+        {% assign translations = value.translation | to_array -%}
+        {% assign code = value | to_array -%}
+        {% assign codes = code | concat: translations %}
+        {% include 'DataType/CodeableConcept' CodeableConcept: codes -%}
+    },
+{% elsif value["xsi:type"] == "BL" -%}
+    "valueBoolean" : {{ value.value }}
+{% elsif value.value -%}
+    "valueQuantity": {
+        "value":{{ value.value }},
+        {% if value.unit and  value.unit != "null" -%}
+        "unit":"{{ value.unit }}",
+        {% endif -%}
+    },
+{% elsif value._ %}
+    "valueString":"{{ value._ }}",
+{% elsif value.originalText._ %}
+    "valueString":"{{ value.originalText._ }}",
+{% else %}
+    {% assign ref = value.reference.value | default: value.originalText.reference.value -%}
+    {% assign refVal = ref | replace: '#', '' -%}
+    {% assign valueString = origText | find_inner_text_by_id: refVal -%}
+    "valueString": "{{ valueString | clean_string_from_tabs | escape_special_chars }}",
+{% endif -%}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/CustomFilters.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/CustomFilters.cs
@@ -521,7 +521,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
     }
 
     /// <summary>
-    /// Searches for the original text content of a node with a specified ID within a 
+    /// Searches for the original text content of a node with a specified ID within a
     /// given xml string (`text._innerText` in most cases).
     /// </summary>
     /// <param name="fullText">The string of XML to search within.</param>
@@ -557,9 +557,9 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
             return res;
           }
         }
-     }
+      }
 
-     return null;
+      return null;
     }
 
     /// <summary>

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/CustomFilters.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/CustomFilters.cs
@@ -305,8 +305,13 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
       return stringBuilder.ToString();
     }
 
-    public static string CleanStringFromTabs(string value)
+    public static string? CleanStringFromTabs(string? value)
     {
+      if (value == null)
+      {
+          return null;
+      }
+
       const string reduceMultiSpace = @"[ ]{2,}";
       return Regex.Replace(value.Replace("\t", " "), reduceMultiSpace, " ");
     }


### PR DESCRIPTION
This PR turned a little meandering - apologies.

* Allow social history entries that have a value which is coded with `nullFlavor = UNK` to still be converted as long as they have original text in their value field
* Make sure that all converted social history observations are referenced in the social history section (and not more than did get converted)
* Abstract out the logic of whether to convert a social history observation to the `Util/IsSocialHistoryObservation` template.
  * This template contains boolean logic to figure out if we should convert it or not then renders the result at the end. We can then `capture` this result when including the template in another template and use its value to simplify/dry out the code there
* Use `case/when` to dry out a lot of repeated template ID-ing (and also add the check to look at the first as sometimes this had more than one thing and then the old logic just wasn't hitting 😬 )
* remove the extra special casing for `SOCIALOBS` in the social history `_entry.liquid` and just make it a normal special case as it wasn't needed and was causing weird merged objects because we were also converting it in the regular way.
* Create a utility template for handling `value[x]` fhir mappings and use it in a lot of places