### PR TITLE
fix: get all emergency contacts

### DIFF
--- a/data/Templates/eCR/Header.liquid
+++ b/data/Templates/eCR/Header.liquid
@@ -138,7 +138,7 @@
 {% if msg.ClinicalDocument.recordTarget.patientRole -%}
   {% assign patientSectionObservations = true -%}
   {% include 'Section/SocialHistory' SOCIALOBS: socialObs SOCIALTEXT: socialHistoryText -%}
-  {% include 'Resource/Patient' patientRole: msg.ClinicalDocument.recordTarget.patientRole ID: patientId SOCIALOBS: socialObs SOCIALTEXT: socialHistoryText contact: msg.ClinicalDocument.participant.associatedEntity -%}
+  {% include 'Resource/Patient' patientRole: msg.ClinicalDocument.recordTarget.patientRole ID: patientId SOCIALOBS: socialObs SOCIALTEXT: socialHistoryText participants: msg.ClinicalDocument.participant -%}
   {% assign careTeam = msg | get_first_ccda_sections_by_template_id: '2.16.840.1.113883.10.20.22.2.500' %} 
   {% if careTeam %}
     {% assign careTeamId = careTeam.2_16_840_1_113883_10_20_22_2_500 | to_json_string | generate_uuid -%}

--- a/data/Templates/eCR/Header.liquid
+++ b/data/Templates/eCR/Header.liquid
@@ -137,8 +137,9 @@
 
 {% if msg.ClinicalDocument.recordTarget.patientRole -%}
   {% assign patientSectionObservations = true -%}
+  {% assign participants = msg.ClinicalDocument.participant | to_array %}
   {% include 'Section/SocialHistory' SOCIALOBS: socialObs SOCIALTEXT: socialHistoryText -%}
-  {% include 'Resource/Patient' patientRole: msg.ClinicalDocument.recordTarget.patientRole ID: patientId SOCIALOBS: socialObs SOCIALTEXT: socialHistoryText participants: msg.ClinicalDocument.participant -%}
+  {% include 'Resource/Patient' patientRole: msg.ClinicalDocument.recordTarget.patientRole ID: patientId SOCIALOBS: socialObs SOCIALTEXT: socialHistoryText participants: participants -%}
   {% assign careTeam = msg | get_first_ccda_sections_by_template_id: '2.16.840.1.113883.10.20.22.2.500' %} 
   {% if careTeam %}
     {% assign careTeamId = careTeam.2_16_840_1_113883_10_20_22_2_500 | to_json_string | generate_uuid -%}

--- a/data/Templates/eCR/Resource/_Patient.liquid
+++ b/data/Templates/eCR/Resource/_Patient.liquid
@@ -62,25 +62,28 @@
             { {% include 'DataType/ContactPoint' ContactPoint: telecom -%} },
             {% endfor -%}
         ],
-        {% if contact.classCode == "ECON" -%}
         "contact": [
-             {
-                "relationship": [
-                    { {% include 'DataType/CodeableConcept' CodeableConcept: contact.code -%} }
-                ],
-                {% assign name = contact.associatedPerson.name | to_array | first-%}
-                "name": { {% include 'DataType/HumanName' HumanName: name -%} },
-                "telecom": [
-                    {% assign telecoms = contact.telecom | to_array -%}
-                    {% for telecom in telecoms -%}
-                    { {% include 'DataType/ContactPoint' ContactPoint: telecom -%} },
-                    {% endfor -%}
-                ],
-                {% assign addr = contact.addr | to_array | first -%}
-                "address": { {% include 'DataType/Address' Address: addr -%} },
-             }
+        {% for participant in participants -%}
+            {% assign contact = participant.associatedEntity -%}
+            {% if contact.classCode == "ECON" -%}
+                {
+                    "relationship": [
+                        { {% include 'DataType/CodeableConcept' CodeableConcept: contact.code -%} }
+                    ],
+                    {% assign name = contact.associatedPerson.name | to_array | first-%}
+                    "name": { {% include 'DataType/HumanName' HumanName: name -%} },
+                    "telecom": [
+                        {% assign telecoms = contact.telecom | to_array -%}
+                        {% for telecom in telecoms -%}
+                        { {% include 'DataType/ContactPoint' ContactPoint: telecom -%} },
+                        {% endfor -%}
+                    ],
+                    {% assign addr = contact.addr | to_array | first -%}
+                    "address": { {% include 'DataType/Address' Address: addr -%} },
+                },
+            {% endif contact  -%}
+        {% endfor -%}
         ],
-        {% endif contact  -%}
         "communication":
         [
             {% assign languageCommunications = patientRole.patient.languageCommunication | to_array -%}


### PR DESCRIPTION
There can be multiple participants and the FHIR spec allows for multiple contacts. This PR loops through the participants to find all contacts.