### PR TITLE
add id and change bundle type to bundle resource

### DIFF
--- a/data/Templates/eCR/EICR.liquid
+++ b/data/Templates/eCR/EICR.liquid
@@ -1,7 +1,8 @@
 {
 "resourceType": "Bundle",
-    "type": "batch",
-    "entry": [{% evaluate patientId using 'Utils/GenerateId' obj: msg.ClinicalDocument.recordTarget.patientRole -%}
+"type": "document",
+"id": "{{ msg.ClinicalDocument.id.root }}",
+"entry": [{% evaluate patientId using 'Utils/GenerateId' obj: msg.ClinicalDocument.recordTarget.patientRole -%}
 {% assign fullPatientId = patientId | prepend: 'Patient/' -%}
 
 {% include 'Header' -%}

--- a/data/Templates/eCR/Header.liquid
+++ b/data/Templates/eCR/Header.liquid
@@ -1,9 +1,5 @@
 {% evaluate practitionerId using 'Utils/GenerateId' obj: msg.ClinicalDocument.componentOf.encompassingEncounter.responsibleParty.assignedEntity -%}
-{% if msg.ClinicalDocument.id and msg.ClinicalDocument.id.root -%}
-  {% assign compositionId = msg.ClinicalDocument.id.root -%}
-{% else -%}
-  {% assign compositionId = msg._originalData | generate_uuid -%}
-{% endif -%}
+{% assign compositionId = msg._originalData | generate_uuid -%}
 {% include 'Resource/Composition' composition: msg.ClinicalDocument, practitionerId: practitionerId, ID: compositionId -%}
 {% include 'Reference/Composition/Subject' ID: compositionId, REF: fullPatientId -%}
 


### PR DESCRIPTION
## Description

- The [bundle type](https://www.hl7.org/fhir/R4/codesystem-bundle-type.html#4.3.14.303.2) is currently always `batch`. Instead it should be `document` because the resources are not standalone items and we use and store the entire bundle as a single document.
- Add an ID to the bundle to be the ID of the eICR document.