### PR TITLE
fix: get all procedure codes

### DIFF
--- a/data/Templates/eCR/DataType/_Coding.liquid
+++ b/data/Templates/eCR/DataType/_Coding.liquid
@@ -4,9 +4,9 @@
 {%- endcapture -%}
 "system": {{ codeSystemName }},
 {% if Coding.displayName -%}
-  "display": "{{ Coding.displayName | strip }}",
+  "display": "{{ Coding.displayName | clean_string_from_tabs | strip }}",
 {% elsif Coding.originalText._ -%}
-  "display": "{{ Coding.originalText._ | strip }}",
+  "display": "{{ Coding.originalText._ | clean_string_from_tabs | strip }}",
 {% elsif Coding.originalText.reference._ -%}
   "display": "{{ Coding.originalText.reference._ }}",
 {% elsif codeSystemName contains "loinc" -%}

--- a/data/Templates/eCR/Entry/Result/_entry_organizer_component.liquid
+++ b/data/Templates/eCR/Entry/Result/_entry_organizer_component.liquid
@@ -1,20 +1,20 @@
 {% if component.observation -%}
   {% if component.observation.code.nullFlavor and component.observation.code.nullFlavor != 'UNK' -%}
-    {% else -%}
-      {% assign observationId = component.observation | to_json_string | generate_uuid -%}
-      {% include 'Resource/Observation' observationCategory: 'laboratory', observationEntry: component.observation, ID: observationId, specimenValue: specValue, collectTime: collectTime, receiveTime: receiveTime, text: text -%}
-      {% assign fullObservationId = observationId | prepend: 'Observation/' -%}
-      {% include 'Reference/DiagnosticReport/Result' ID: diagnosticId, REF: fullObservationId -%}
-      {% include 'Reference/Observation/Subject' ID: observationId, REF: fullPatientId -%}
+  {% else -%}
+    {% assign observationId = component.observation | to_json_string | generate_uuid -%}
+    {% include 'Resource/Observation' observationCategory: 'laboratory', observationEntry: component.observation, ID: observationId, specimenValue: specValue, collectTime: collectTime, receiveTime: receiveTime, text: text -%}
+    {% assign fullObservationId = observationId | prepend: 'Observation/' -%}
+    {% include 'Reference/DiagnosticReport/Result' ID: diagnosticId, REF: fullObservationId -%}
+    {% include 'Reference/Observation/Subject' ID: observationId, REF: fullPatientId -%}
 
-      {% assign labDeviceNameReference = component.observation.text.reference.value | replace: '#', '' | append: 'TestMethodName1'-%}
-      {% assign labDeviceName = text._innerText | find_inner_text_by_id: labDeviceNameReference | clean_string_from_tabs | escape_special_chars -%}
-      {% if labDeviceName != null and labDeviceName != "" %}
-        {% assign deviceId = labDeviceName | generate_uuid %}
-        {% assign fullDeviceId = deviceId | prepend: 'Device/' %}
-        {% include 'Resource/Device2', ID: deviceId, deviceName: labDeviceName -%}
-        {% include 'Reference/Observation/Device', ID: observationId, REF: fullDeviceId -%}
-      {% endif %}
+    {% assign labDeviceNameReference = component.observation.text.reference.value | replace: '#', '' | append: 'TestMethodName1'-%}
+    {% assign labDeviceName = text._innerText | find_inner_text_by_id: labDeviceNameReference | clean_string_from_tabs | escape_special_chars -%}
+    {% if labDeviceName != null and labDeviceName != "" %}
+      {% assign deviceId = labDeviceName | generate_uuid %}
+      {% assign fullDeviceId = deviceId | prepend: 'Device/' %}
+      {% include 'Resource/Device2', ID: deviceId, deviceName: labDeviceName -%}
+      {% include 'Reference/Observation/Device', ID: observationId, REF: fullDeviceId -%}
+    {% endif %}
 
     {% if component.observation.author.assignedAuthor -%}
         {% evaluate practitionerResultId using 'Utils/GenerateId' obj: component.observation.author.assignedAuthor -%}
@@ -32,11 +32,11 @@
 {% endif -%}
 {% if component.organizer and component.organizer.classCode == "BATTERY" %}
   {% if component.organizer.code.nullFlavor and component.observation.code.nullFlavor != 'UNK' -%}
-    {% else -%}
-      {% assign observationId = component.organizer | to_json_string | generate_uuid -%}
-      {% include 'Resource/Observation' observationCategory: 'laboratory', observationEntry: component.organizer, ID: observationId, classCode: component.organizer.classCode -%}
-      {% assign fullObservationId = observationId | prepend: 'Observation/' -%}
-      {% include 'Reference/DiagnosticReport/Result' ID: diagnosticId, REF: fullObservationId -%}
-      {% include 'Reference/Observation/Subject' ID: observationId, REF: fullPatientId -%}
+  {% else -%}
+    {% assign observationId = component.organizer | to_json_string | generate_uuid -%}
+    {% include 'Resource/Observation' observationCategory: 'laboratory', observationEntry: component.organizer, ID: observationId, classCode: component.organizer.classCode -%}
+    {% assign fullObservationId = observationId | prepend: 'Observation/' -%}
+    {% include 'Reference/DiagnosticReport/Result' ID: diagnosticId, REF: fullObservationId -%}
+    {% include 'Reference/Observation/Subject' ID: observationId, REF: fullPatientId -%}
   {% endif -%}    
 {% endif -%}

--- a/data/Templates/eCR/Resource/_Composition.liquid
+++ b/data/Templates/eCR/Resource/_Composition.liquid
@@ -72,8 +72,7 @@
                     {% endif -%}
                     {% if component.section.title._ -%}
                     "title":"{{ component.section.title._ }}",
-                    {% endif -%}
-                    {% if component.section.title._ == null -%}
+                    {% else -%}
                     "title":"{{ component.section.code.displayName }}",
                     {% endif -%}
                     "text":
@@ -183,13 +182,13 @@
                                         {% assign observationId = orgComp.observation | to_json_string | generate_uuid -%}
                                         {% assign fullObservationId = observationId | prepend: 'Observation/' -%}
                                         {
+                                            "reference": "{{ fullObservationId }}",
                                             {% if orgComp.observation.code.originalText._ -%}
-                                                "display": "{{orgComp.observation.code.originalText._ | strip}}",
+                                                "display": "{{orgComp.observation.code.originalText._ | clean_string_from_tabs | strip}}",
                                             {% elsif orgComp.observation.code.translation -%}
                                                 {% assign translations = orgComp.observation.code.translation | to_array -%}
                                                 "display": "{{translations.first.displayName | strip}}",
                                             {% endif -%}
-                                            "reference": "{{ fullObservationId }}",
                                         },
                                         {% endif -%}
                                     {% endif -%}

--- a/data/Templates/eCR/Resource/_Procedure.liquid
+++ b/data/Templates/eCR/Resource/_Procedure.liquid
@@ -17,7 +17,10 @@
         "status":"{{ procedureEntry.statusCode.code }}",
         "code":
         {
-            {% include 'DataType/CodeableConcept' CodeableConcept: procedureEntry.code -%}
+            {% assign translations = procedureEntry.code.translation | to_array -%}
+            {% assign code = procedureEntry.code | to_array -%}
+            {% assign codes = code | concat: translations -%}
+            {% include 'DataType/CodeableConcept' CodeableConcept: codes -%}
         },
         {% if procedureEntry.effectiveTime.value -%}
             "performedDateTime":"{{ procedureEntry.effectiveTime.value | format_as_date_time }}",
@@ -35,7 +38,7 @@
         "reason": 
         [
             {
-                "display": "{{procedureEntry.entryRelationship.observation.text._}}",
+                "display": "{{procedureEntry.entryRelationship.observation.text._ | clean_string_from_tabs | strip}}",
                 "reference": "{{procedureEntry.entryRelationship.observation | to_json_string | generate_uuid}}",
             },
         ],


### PR DESCRIPTION
Return all procedure codes instead of just the first.

Also cleaned up some whitespace issues, stripping out of tabs from data, and simplifying some branching while I was here. (I recommend reviewing with the ignore whitespace changes enabled)