### PR TITLE
fix: specimen source handling

### DIFF
--- a/data/SampleData/eCR/eCR_full.xml
+++ b/data/SampleData/eCR/eCR_full.xml
@@ -1,0 +1,5790 @@
+<ClinicalDocument xmlns="urn:hl7-org:v3">
+    <realmCode code="US" />
+    <typeId extension="POCD_HD000040" root="2.16.840.1.113883.1.3" />
+    <templateId root="1.2.840.114350.1.72.1.51693" />
+    <templateId root="2.16.840.1.113883.10.20.22.1.1" />
+    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.1.1" />
+    <templateId extension="2016-12-01" root="2.16.840.1.113883.10.20.15.2" />
+    <id assigningAuthorityName="EPC" root="1.2.840.114350.1.13.297.3.7.8.688883.538441" />
+    <code code="55751-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+        displayName="Initial Public Health Case Report" />
+    <title>Initial Public Health Case Report</title>
+    <effectiveTime value="20220928140101-0700" />
+    <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" displayName="Normal" />
+    <languageCode code="en-US" />
+    <setId assigningAuthorityName="EPC" extension="7a89f990-3f70-11ed-9549-c301d81100b2"
+        root="1.2.840.114350.1.13.297.3.7.1.1" />
+    <versionNumber value="15" />
+    <recordTarget>
+        <patientRole>
+            <id extension="POC7649102" root="1.2.840.114350.1.13.297.3.7.3.688884.100" />
+            <addr use="HP">
+                <streetAddressLine>9 Post Lane</streetAddressLine>
+                <city>NEWPORT BEACH</city>
+                <state>CA</state>
+                <postalCode>92663</postalCode>
+                <country>USA</country>
+                <useablePeriod xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:type="IVL_TS">
+                    <low value="20190410" />
+                    <high nullFlavor="NA" />
+                </useablePeriod>
+            </addr>
+            <telecom use="HP" value="tel:+1-949-264-1098" />
+            <telecom value="mailto:mary.gibbs@Providence.org" />
+            <patient>
+                <name use="L">
+                    <given>Adam</given>
+                    <family>Test</family>
+                    <validTime>
+                        <low nullFlavor="NA" />
+                        <high nullFlavor="NA" />
+                    </validTime>
+                </name>
+                <administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1"
+                    codeSystemName="AdministrativeGenderCode" displayName="Male" />
+                <birthTime value="19700101" />
+                <sdtc:deceasedInd xmlns:sdtc="urn:hl7-org:sdtc" value="false" />
+                <maritalStatusCode code="M" codeSystem="2.16.840.1.113883.5.2"
+                    codeSystemName="MaritalStatusCode" displayName="Married" />
+                <religiousAffiliationCode code="Baptist" codeSystem="2.16.840.1.113883.5.1076"
+                    codeSystemName="ReligiousAffiliation" />
+                <raceCode code="2106-3" codeSystem="2.16.840.1.113883.6.238"
+                    codeSystemName="CDC Race and Ethnicity" displayName="White" />
+                <ethnicGroupCode code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+                    codeSystemName="CDC Race and Ethnicity" displayName="Not Hispanic or Latino" />
+                <languageCommunication>
+                    <languageCode nullFlavor="UNK" />
+                </languageCommunication>
+            </patient>
+            <providerOrganization>
+                <id extension="50" root="1.2.840.114350.1.13.297.3.7.2.696570" />
+                <name>Providence California</name>
+                <telecom use="WP" value="tel:+1-855-415-6179" />
+                <addr use="WP">
+                    <streetAddressLine>4733 TORRANCE BLVD #4400</streetAddressLine>
+                    <county>LOS ANGELES</county>
+                    <city>TORRANCE</city>
+                    <state>CA</state>
+                    <postalCode>90503</postalCode>
+                    <country>USA</country>
+                </addr>
+            </providerOrganization>
+        </patientRole>
+    </recordTarget>
+    <author>
+        <time value="20220928140101-0700" />
+        <assignedAuthor>
+            <id extension="LABBACKGROUND" root="1.2.840.114350.1.13.297.3.7.2.697780" />
+            <addr use="WP">
+                <streetAddressLine nullFlavor="UNK" />
+                <city nullFlavor="UNK" />
+                <state nullFlavor="UNK" />
+                <postalCode nullFlavor="UNK" />
+            </addr>
+            <telecom nullFlavor="UNK" />
+            <assignedPerson classCode="PSN" determinerCode="INSTANCE">
+                <name>
+                    <given>Background</given>
+                    <family>Lab</family>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id extension="50" root="1.2.840.114350.1.13.297.3.7.2.696570" />
+                <name>Providence California</name>
+                <telecom use="WP" value="tel:+1-855-415-6179" />
+                <addr use="WP">
+                    <streetAddressLine>4733 TORRANCE BLVD #4400</streetAddressLine>
+                    <county>LOS ANGELES</county>
+                    <city>TORRANCE</city>
+                    <state>CA</state>
+                    <postalCode>90503</postalCode>
+                    <country>USA</country>
+                </addr>
+            </representedOrganization>
+        </assignedAuthor>
+    </author>
+    <author>
+        <time value="20220928140101-0700" />
+        <assignedAuthor>
+            <id extension="10.1" root="1.2.840.114350.1.1" />
+            <addr>
+                <streetAddressLine nullFlavor="UNK" />
+                <city nullFlavor="UNK" />
+                <state nullFlavor="UNK" />
+                <postalCode nullFlavor="UNK" />
+            </addr>
+            <telecom nullFlavor="NA" />
+            <assignedAuthoringDevice>
+                <manufacturerModelName>Epic - Version 10.1</manufacturerModelName>
+                <softwareName>Epic - Version 10.1</softwareName>
+            </assignedAuthoringDevice>
+            <representedOrganization>
+                <id extension="50" root="1.2.840.114350.1.13.297.3.7.2.696570" />
+                <name>Providence California</name>
+                <telecom use="WP" value="tel:+1-855-415-6179" />
+                <addr use="WP">
+                    <streetAddressLine>4733 TORRANCE BLVD #4400</streetAddressLine>
+                    <county>LOS ANGELES</county>
+                    <city>TORRANCE</city>
+                    <state>CA</state>
+                    <postalCode>90503</postalCode>
+                    <country>USA</country>
+                </addr>
+            </representedOrganization>
+        </assignedAuthor>
+    </author>
+    <custodian>
+        <assignedCustodian>
+            <representedCustodianOrganization>
+                <id extension="50" root="1.2.840.114350.1.13.297.3.7.2.696570" />
+                <name>Providence California</name>
+                <telecom use="WP" value="tel:+1-855-415-6179" />
+                <addr use="WP">
+                    <streetAddressLine>4733 TORRANCE BLVD #4400</streetAddressLine>
+                    <county>LOS ANGELES</county>
+                    <city>TORRANCE</city>
+                    <state>CA</state>
+                    <postalCode>90503</postalCode>
+                    <country>USA</country>
+                </addr>
+            </representedCustodianOrganization>
+        </assignedCustodian>
+    </custodian>
+    <participant typeCode="IND">
+        <time value="20190410" />
+        <associatedEntity classCode="ECON">
+            <id extension="72229" root="1.2.840.114350.1.13.297.3.7.2.827665" />
+            <code nullFlavor="OTH">
+                <originalText>Father</originalText>
+            </code>
+            <addr use="HP">
+                <streetAddressLine nullFlavor="UNK" />
+                <city nullFlavor="UNK" />
+                <state nullFlavor="UNK" />
+                <postalCode nullFlavor="UNK" />
+            </addr>
+            <telecom use="HP" value="tel:+1-777-666-5656" />
+            <associatedPerson>
+                <name>
+                    <given nullFlavor="UNK" />
+                    <family nullFlavor="UNK" />
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <relatedDocument typeCode="RPLC">
+        <parentDocument>
+            <id assigningAuthorityName="EPC" root="1.2.840.114350.1.13.297.3.7.8.688883.538440" />
+            <setId assigningAuthorityName="EPC" extension="7a89f990-3f70-11ed-9549-c301d81100b2"
+                root="1.2.840.114350.1.13.297.3.7.1.1" />
+            <versionNumber value="14" />
+        </parentDocument>
+    </relatedDocument>
+    <componentOf>
+        <encompassingEncounter>
+            <id extension="50000595021" root="1.2.840.114350.1.13.297.3.7.3.698084.8" />
+            <code code="AMB" codeSystem="2.16.840.1.113883.5.4" displayName="Ambulatory"
+                nullFlavor="UNK">
+                <originalText>Lab Requisition</originalText>
+                <translation code="4" codeSystem="1.2.840.114350.1.72.1.30.1" />
+            </code>
+            <effectiveTime>
+                <low value="20220928" />
+                <high value="20220928" />
+            </effectiveTime>
+            <responsibleParty>
+                <assignedEntity>
+                    <id nullFlavor="NA" root="2.16.840.1.113883.4.6" />
+                    <addr use="WP">
+                        <streetAddressLine nullFlavor="UNK" />
+                        <city nullFlavor="UNK" />
+                        <state nullFlavor="UNK" />
+                        <postalCode nullFlavor="UNK" />
+                    </addr>
+                    <telecom nullFlavor="NA" />
+                    <assignedPerson>
+                        <name>
+                            <given nullFlavor="UNK" />
+                            <family nullFlavor="UNK" />
+                        </name>
+                    </assignedPerson>
+                    <representedOrganization>
+                        <name>Providence California</name>
+                        <addr use="WP">
+                            <streetAddressLine>4733 TORRANCE BLVD #4400</streetAddressLine>
+                            <county>LOS ANGELES</county>
+                            <city>TORRANCE</city>
+                            <state>CA</state>
+                            <postalCode>90503</postalCode>
+                            <country>USA</country>
+                        </addr>
+                    </representedOrganization>
+                </assignedEntity>
+            </responsibleParty>
+            <encounterParticipant typeCode="ATND">
+                <time value="20220928" />
+                <assignedEntity>
+                    <id nullFlavor="UNK" root="2.16.840.1.113883.4.6" />
+                    <code nullFlavor="OTH">
+                        <originalText>Endocrinology</originalText>
+                        <translation code="18" codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4160"
+                            codeSystemName="Epic.DXC.StandardProviderSpecialtyType"
+                            displayName="Endocrinology" />
+                        <translation code="7"
+                            codeSystem="1.2.840.114350.1.13.297.3.7.10.836982.1050"
+                            codeSystemName="Epic.SER.ProviderSpecialty" displayName="Endocrinology" />
+                    </code>
+                    <addr use="WP">
+                        <streetAddressLine>2001 LIND AVE</streetAddressLine>
+                        <city>RENTON</city>
+                        <state>WA</state>
+                        <postalCode>98059</postalCode>
+                    </addr>
+                    <telecom nullFlavor="UNK" />
+                    <assignedPerson>
+                        <name use="L">
+                            <given>Ambhp1</given>
+                            <family>Test</family>
+                            <suffix qualifier="AC"> MD</suffix>
+                            <validTime>
+                                <low nullFlavor="UNK" />
+                                <high nullFlavor="UNK" />
+                            </validTime>
+                        </name>
+                    </assignedPerson>
+                </assignedEntity>
+            </encounterParticipant>
+            <location>
+                <healthCareFacility>
+                    <id extension="501122000" root="1.2.840.114350.1.13.297.3.7.2.686980" />
+                    <code code="257622000" codeSystem="2.16.840.1.113883.6.96"
+                        displayName="Healthcare Facility">
+                        <originalText>Lab</originalText>
+                    </code>
+                    <location>
+                        <name>PROVIDENCE ST JOSEPH MED CTR LABORATORY</name>
+                        <addr use="WP">
+                            <streetAddressLine>501 S Buena Vista St</streetAddressLine>
+                            <county>LOS ANGELES</county>
+                            <city>Burbank</city>
+                            <state>CA</state>
+                            <postalCode>91505-4809</postalCode>
+                            <country>USA</country>
+                        </addr>
+                    </location>
+                    <serviceProviderOrganization>
+                        <id extension="501121" root="1.2.840.114350.1.13.297.3.7.2.696570" />
+                        <name>Providence St Joseph Medical Center</name>
+                        <telecom nullFlavor="UNK" />
+                        <addr use="WP">
+                            <streetAddressLine>501 S Buena Vista St</streetAddressLine>
+                            <county>LOS ANGELES</county>
+                            <city>Burbank</city>
+                            <state>CA</state>
+                            <postalCode>91505-4809</postalCode>
+                            <country>USA</country>
+                        </addr>
+                        <asOrganizationPartOf>
+                            <wholeOrganization>
+                                <name>Providence California</name>
+                                <addr nullFlavor="NA" />
+                            </wholeOrganization>
+                        </asOrganizationPartOf>
+                    </serviceProviderOrganization>
+                </healthCareFacility>
+            </location>
+        </encompassingEncounter>
+    </componentOf>
+    <component>
+        <structuredBody>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.4" />
+                    <code code="10164-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="HISTORY OF PRESENT ILLNESS" />
+                    <title>Miscellaneous Notes</title>
+                    <text>
+                        <content ID="nof2">Not on file</content>
+                        <footnote ID="subTitle1" styleCode="xSectionSubTitle">documented in this
+                            encounter</footnote>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2" />
+                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.2" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2.1" />
+                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.2.1" />
+                    <id root="A84C7F7E-3F70-11ED-9549-C301D81100B2" />
+                    <code code="11369-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="History of Immunization Narrative" />
+                    <title>Immunizations</title>
+                    <text>
+                        <table>
+                            <colgroup>
+                                <col width="25%" />
+                                <col width="50%" />
+                                <col width="25%" />
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Administration Dates</th>
+                                    <th>Next Due</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr ID="immunization4">
+                                    <td ID="immunization4Name">DTAP-HIB-IPV (PENTACEL)</td>
+                                    <td>
+                                        <content>04/16/2010</content>
+                                    </td>
+                                    <td />
+                                </tr>
+                                <tr ID="immunization6">
+                                    <td ID="immunization6Name">HEP A (ADULT) 2 DOSE</td>
+                                    <td>
+                                        <content>11/11/2011</content>
+                                    </td>
+                                    <td />
+                                </tr>
+                                <tr ID="immunization8">
+                                    <td ID="immunization8Name">HEP B (PED,ADOLESCENT) 3 DOSE</td>
+                                    <td>
+                                        <content>03/21/1974</content>
+                                    </td>
+                                    <td />
+                                </tr>
+                                <tr ID="immunization7">
+                                    <td ID="immunization7Name">MENINGOCOCCAL CONJUGATE,MENACTRA
+                                        (PED/ADOL/ADULT)</td>
+                                    <td>
+                                        <content>11/16/2020</content>
+                                    </td>
+                                    <td />
+                                </tr>
+                                <tr ID="immunization5">
+                                    <td ID="immunization5Name">TDAP, (ADOL/ADULT)</td>
+                                    <td>
+                                        <content>11/10/2020</content>
+                                    </td>
+                                    <td />
+                                </tr>
+                            </tbody>
+                        </table>
+                        <footnote ID="subTitle3" styleCode="xSectionSubTitle">documented as of this
+                            encounter</footnote>
+                    </text>
+                    <entry>
+                        <substanceAdministration classCode="SBADM" moodCode="EVN"
+                            negationInd="false">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52" />
+                            <templateId extension="2015-08-01"
+                                root="2.16.840.1.113883.10.20.22.4.52" />
+                            <id extension="35371" root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                            <code code="IMMUNIZ" codeSystem="2.16.840.1.113883.5.4"
+                                codeSystemName="ActCode" />
+                            <text>
+                                <reference value="#immunization4" />
+                            </text>
+                            <statusCode code="completed" />
+                            <effectiveTime value="20100416" />
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54" />
+                                    <templateId extension="2014-06-09"
+                                        root="2.16.840.1.113883.10.20.22.4.54" />
+                                    <manufacturedMaterial>
+                                        <code nullFlavor="OTH">
+                                            <originalText>
+                                                <reference value="#immunization4Name" />
+                                            </originalText>
+                                        </code>
+                                        <lotNumberText nullFlavor="UNK" />
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId extension="2019-10-01"
+                                    root="2.16.840.1.113883.10.20.22.5.6" />
+                                <time value="20190416091055-0700" />
+                                <assignedAuthor>
+                                    <id extension="195858804"
+                                        root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                    <id root="2.16.840.1.113883.4.6" />
+                                    <code nullFlavor="OTH">
+                                        <originalText>Registered Nurse</originalText>
+                                        <translation code="168"
+                                            codeSystem="1.2.840.114350.1.13.297.3.7.10.836982.1050"
+                                            codeSystemName="Epic.SER.ProviderSpecialty"
+                                            displayName="Registered Nurse" />
+                                    </code>
+                                    <telecom nullFlavor="UNK" />
+                                    <representedOrganization>
+                                        <id extension="50"
+                                            root="1.2.840.114350.1.13.297.3.7.2.696570" />
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.2" />
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.6" />
+                                        <name>Providence California</name>
+                                        <telecom use="WP" value="tel:+1-855-415-6179" />
+                                        <addr use="WP">
+                                            <streetAddressLine>4733 TORRANCE BLVD #4400</streetAddressLine>
+                                            <county>LOS ANGELES</county>
+                                            <city>TORRANCE</city>
+                                            <state>CA</state>
+                                            <postalCode>90503</postalCode>
+                                            <country>USA</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </substanceAdministration>
+                    </entry>
+                    <entry>
+                        <substanceAdministration classCode="SBADM" moodCode="EVN"
+                            negationInd="false">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52" />
+                            <templateId extension="2015-08-01"
+                                root="2.16.840.1.113883.10.20.22.4.52" />
+                            <id extension="57643" root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                            <code code="IMMUNIZ" codeSystem="2.16.840.1.113883.5.4"
+                                codeSystemName="ActCode" />
+                            <text>
+                                <reference value="#immunization5" />
+                            </text>
+                            <statusCode code="completed" />
+                            <effectiveTime value="20201110" />
+                            <doseQuantity unit="mL" value=".5" />
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54" />
+                                    <templateId extension="2014-06-09"
+                                        root="2.16.840.1.113883.10.20.22.4.54" />
+                                    <manufacturedMaterial>
+                                        <code nullFlavor="OTH">
+                                            <originalText>
+                                                <reference value="#immunization5Name" />
+                                            </originalText>
+                                            <translation code="49281-400-10"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC" />
+                                        </code>
+                                        <lotNumberText>369258741</lotNumberText>
+                                    </manufacturedMaterial>
+                                    <manufacturerOrganization>
+                                        <name>Sanofi Pasteur</name>
+                                    </manufacturerOrganization>
+                                </manufacturedProduct>
+                            </consumable>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK" root="2.16.840.1.113883.4.6" />
+                                    <addr use="WP">
+                                        <streetAddressLine nullFlavor="UNK" />
+                                        <city nullFlavor="UNK" />
+                                        <state nullFlavor="UNK" />
+                                        <postalCode nullFlavor="UNK" />
+                                    </addr>
+                                    <telecom nullFlavor="UNK" />
+                                    <assignedPerson>
+                                        <name>
+                                            <given>Provma</given>
+                                            <given>Two</given>
+                                            <family>Ambtest</family>
+                                            <suffix qualifier="AC">CMA</suffix>
+                                        </name>
+                                    </assignedPerson>
+                                </assignedEntity>
+                            </performer>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId extension="2019-10-01"
+                                    root="2.16.840.1.113883.10.20.22.5.6" />
+                                <time value="20201110154842-0800" />
+                                <assignedAuthor>
+                                    <id extension="326310445"
+                                        root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                    <id root="2.16.840.1.113883.4.6" />
+                                    <telecom nullFlavor="UNK" />
+                                    <representedOrganization>
+                                        <id extension="50"
+                                            root="1.2.840.114350.1.13.297.3.7.2.696570" />
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.2" />
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.6" />
+                                        <name>Providence California</name>
+                                        <telecom use="WP" value="tel:+1-855-415-6179" />
+                                        <addr use="WP">
+                                            <streetAddressLine>4733 TORRANCE BLVD #4400</streetAddressLine>
+                                            <county>LOS ANGELES</county>
+                                            <city>TORRANCE</city>
+                                            <state>CA</state>
+                                            <postalCode>90503</postalCode>
+                                            <country>USA</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </substanceAdministration>
+                    </entry>
+                    <entry>
+                        <substanceAdministration classCode="SBADM" moodCode="EVN"
+                            negationInd="false">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52" />
+                            <templateId extension="2015-08-01"
+                                root="2.16.840.1.113883.10.20.22.4.52" />
+                            <id extension="57644" root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                            <code code="IMMUNIZ" codeSystem="2.16.840.1.113883.5.4"
+                                codeSystemName="ActCode" />
+                            <text>
+                                <reference value="#immunization6" />
+                            </text>
+                            <statusCode code="completed" />
+                            <effectiveTime value="20111111" />
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54" />
+                                    <templateId extension="2014-06-09"
+                                        root="2.16.840.1.113883.10.20.22.4.54" />
+                                    <manufacturedMaterial>
+                                        <code nullFlavor="OTH">
+                                            <originalText>
+                                                <reference value="#immunization6Name" />
+                                            </originalText>
+                                        </code>
+                                        <lotNumberText nullFlavor="UNK" />
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId extension="2019-10-01"
+                                    root="2.16.840.1.113883.10.20.22.5.6" />
+                                <time value="20201110154900-0800" />
+                                <assignedAuthor>
+                                    <id extension="326310445"
+                                        root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                    <id root="2.16.840.1.113883.4.6" />
+                                </assignedAuthor>
+                            </author>
+                        </substanceAdministration>
+                    </entry>
+                    <entry>
+                        <substanceAdministration classCode="SBADM" moodCode="EVN"
+                            negationInd="false">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52" />
+                            <templateId extension="2015-08-01"
+                                root="2.16.840.1.113883.10.20.22.4.52" />
+                            <id extension="58353" root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                            <code code="IMMUNIZ" codeSystem="2.16.840.1.113883.5.4"
+                                codeSystemName="ActCode" />
+                            <text>
+                                <reference value="#immunization7" />
+                            </text>
+                            <statusCode code="completed" />
+                            <effectiveTime value="20201116" />
+                            <doseQuantity unit="mL" value=".5" />
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54" />
+                                    <templateId extension="2014-06-09"
+                                        root="2.16.840.1.113883.10.20.22.4.54" />
+                                    <manufacturedMaterial>
+                                        <code nullFlavor="OTH">
+                                            <originalText>
+                                                <reference value="#immunization7Name" />
+                                            </originalText>
+                                            <translation code="50090-1890-1"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC" />
+                                        </code>
+                                        <lotNumberText>1</lotNumberText>
+                                    </manufacturedMaterial>
+                                    <manufacturerOrganization>
+                                        <name>Sanofi Pasteur</name>
+                                    </manufacturerOrganization>
+                                </manufacturedProduct>
+                            </consumable>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK" root="2.16.840.1.113883.4.6" />
+                                    <addr use="WP">
+                                        <streetAddressLine nullFlavor="UNK" />
+                                        <city nullFlavor="UNK" />
+                                        <state nullFlavor="UNK" />
+                                        <postalCode nullFlavor="UNK" />
+                                    </addr>
+                                    <telecom nullFlavor="UNK" />
+                                    <assignedPerson>
+                                        <name>
+                                            <given>Provma</given>
+                                            <given>Two</given>
+                                            <family>Ambtest</family>
+                                            <suffix qualifier="AC">CMA</suffix>
+                                        </name>
+                                    </assignedPerson>
+                                </assignedEntity>
+                            </performer>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId extension="2019-10-01"
+                                    root="2.16.840.1.113883.10.20.22.5.6" />
+                                <time value="20201116182245-0800" />
+                                <assignedAuthor>
+                                    <id extension="326310445"
+                                        root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                    <id root="2.16.840.1.113883.4.6" />
+                                </assignedAuthor>
+                            </author>
+                        </substanceAdministration>
+                    </entry>
+                    <entry>
+                        <substanceAdministration classCode="SBADM" moodCode="EVN"
+                            negationInd="false">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52" />
+                            <templateId extension="2015-08-01"
+                                root="2.16.840.1.113883.10.20.22.4.52" />
+                            <id extension="58354" root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                            <code code="IMMUNIZ" codeSystem="2.16.840.1.113883.5.4"
+                                codeSystemName="ActCode" />
+                            <text>
+                                <reference value="#immunization8" />
+                            </text>
+                            <statusCode code="completed" />
+                            <effectiveTime value="19740321" />
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54" />
+                                    <templateId extension="2014-06-09"
+                                        root="2.16.840.1.113883.10.20.22.4.54" />
+                                    <manufacturedMaterial>
+                                        <code nullFlavor="OTH">
+                                            <originalText>
+                                                <reference value="#immunization8Name" />
+                                            </originalText>
+                                        </code>
+                                        <lotNumberText nullFlavor="UNK" />
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId extension="2019-10-01"
+                                    root="2.16.840.1.113883.10.20.22.5.6" />
+                                <time value="20201116182326-0800" />
+                                <assignedAuthor>
+                                    <id extension="326310445"
+                                        root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                    <id root="2.16.840.1.113883.4.6" />
+                                </assignedAuthor>
+                            </author>
+                        </substanceAdministration>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.38" />
+                    <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.2.38" />
+                    <id root="A853DBC0-3F70-11ED-9549-C301D81100B2" />
+                    <code code="29549-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="MEDICATIONS ADMINISTERED" />
+                    <title>Administered Medications</title>
+                    <text>
+                        <content ID="nof10">Not on file</content>
+                        <footnote ID="subTitle9" styleCode="xSectionSubTitle">documented in this
+                            encounter</footnote>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.10" />
+                    <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.2.10" />
+                    <code code="18776-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="Plan of care note" />
+                    <title>Plan of Treatment</title>
+                    <text>
+                        <paragraph>Not on file</paragraph>
+                        <footnote ID="subTitle11" styleCode="xSectionSubTitle">documented as of this
+                            encounter</footnote>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1" />
+                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.5.1" />
+                    <id root="A8648114-3F70-11ED-9549-C301D81100B2" />
+                    <code code="11450-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="Problem list - Reported" />
+                    <title>Problems</title>
+                    <text>
+                        <table>
+                            <colgroup>
+                                <col width="75%" />
+                                <col width="25%" />
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Active Problems</th>
+                                    <th>Noted Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr ID="problem20" styleCode="xRowNormal">
+                                    <td ID="problem20name">Bipolar I disorder</td>
+                                    <td>11/19/20</td>
+                                </tr>
+                                <tr ID="problem21" styleCode="xRowAlt">
+                                    <td ID="problem21name">Reactive depression</td>
+                                    <td>11/19/20</td>
+                                </tr>
+                                <tr ID="problem18" styleCode="xRowNormal">
+                                    <td ID="problem18name">Rheumatoid arthritis with negative
+                                        rheumatoid factor</td>
+                                    <td>11/16/20</td>
+                                </tr>
+                                <tr ID="problem19" styleCode="xRowAlt">
+                                    <td ID="problem19name">Arthralgia of both ankles</td>
+                                    <td>11/16/20</td>
+                                </tr>
+                                <tr ID="problem16" styleCode="xRowNormal">
+                                    <td ID="problem16name">Anxiety</td>
+                                    <td>11/10/20</td>
+                                </tr>
+                                <tr ID="problem17" styleCode="xRowAlt">
+                                    <td ID="problem17name">Asthma</td>
+                                    <td>11/10/20</td>
+                                </tr>
+                                <tr ID="problem15" styleCode="xRowNormal">
+                                    <td ID="problem15name">Knee pain</td>
+                                    <td>4/29/19</td>
+                                </tr>
+                                <tr ID="problem14" styleCode="xRowAlt">
+                                    <td ID="problem14name">Sprain of calcaneofibular ligament of
+                                        right ankle</td>
+                                    <td>4/16/19</td>
+                                </tr>
+                                <tr styleCode="xRowAlt xMergeUp">
+                                    <td ID="problem14comment" colspan="2" styleCode="xallIndent">
+                                        <content>A note:</content>
+                                        <paragraph styleCode="xcellHeader">Last Assessment &amp;
+                                            Plan: </paragraph>
+                                        <content><content styleCode="xLabel">Formatting of this note
+                                            might be different from the original.</content><br />This
+                                            is my note about this problem.</content>
+                                        <br />
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <footnote ID="subTitle13" styleCode="xSectionSubTitle">documented as of this
+                            encounter (statuses as of 09/28/2022)</footnote>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" />
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.3" />
+                            <id extension="35372-concern"
+                                root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass" displayName="Concern" />
+                            <text>
+                                <reference value="#problem14" />
+                            </text>
+                            <statusCode code="active" />
+                            <effectiveTime>
+                                <low value="20190416" />
+                            </effectiveTime>
+                            <entryRelationship inversionInd="false" typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.4" />
+                                    <id extension="35372"
+                                        root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                                    <code code="64572001" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75323-6"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC" />
+                                    </code>
+                                    <text>
+                                        <reference value="#problem14name" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime>
+                                        <low value="20190416" />
+                                    </effectiveTime>
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        code="11833511000119101" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#problem14name" />
+                                        </originalText>
+                                        <translation code="S93.411A"
+                                            codeSystem="2.16.840.1.113883.6.90"
+                                            codeSystemName="ICD10"
+                                            displayName="Sprain of calcaneofibular ligament of right ankle" />
+                                        <translation code="845.02"
+                                            codeSystem="2.16.840.1.113883.6.103"
+                                            codeSystemName="ICD9"
+                                            displayName="Sprain of calcaneofibular ligament of right ankle" />
+                                        <translation code="1608716"
+                                            codeSystem="2.16.840.1.113883.3.247.1.1"
+                                            codeSystemName="Intelligent Medical Objects ProblemIT"
+                                            displayName="Sprain of calcaneofibular ligament of right ankle" />
+                                    </value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId extension="2019-10-01"
+                                            root="2.16.840.1.113883.10.20.22.5.6" />
+                                        <time value="20190416091227-0700" />
+                                        <assignedAuthor>
+                                            <id extension="195858797"
+                                                root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                            <id extension="1111111113" root="2.16.840.1.113883.4.6" />
+                                            <code code="207Q00000X"
+                                                codeSystem="2.16.840.1.113883.6.101"
+                                                displayName="Family Medicine">
+                                                <originalText>Family Medicine</originalText>
+                                                <translation code="19"
+                                                    codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4160"
+                                                    codeSystemName="Epic.DXC.StandardProviderSpecialtyType"
+                                                    displayName="Family Medicine" />
+                                                <translation code="9"
+                                                    codeSystem="1.2.840.114350.1.13.297.3.7.10.836982.1050"
+                                                    codeSystemName="Epic.SER.ProviderSpecialty"
+                                                    displayName="Family Medicine" />
+                                            </code>
+                                            <telecom nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <id extension="50"
+                                                    root="1.2.840.114350.1.13.297.3.7.2.696570" />
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.2" />
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.6" />
+                                                <name>Providence California</name>
+                                                <telecom use="WP" value="tel:+1-855-415-6179" />
+                                                <addr use="WP">
+                                                    <streetAddressLine>4733 TORRANCE BLVD #4400</streetAddressLine>
+                                                    <county>LOS ANGELES</county>
+                                                    <city>TORRANCE</city>
+                                                    <state>CA</state>
+                                                    <postalCode>90503</postalCode>
+                                                    <country>USA</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6" />
+                                            <code code="33999-4" codeSystem="2.16.840.1.113883.6.1"
+                                                displayName="Status" />
+                                            <statusCode code="completed" />
+                                            <effectiveTime>
+                                                <low value="20190416" />
+                                            </effectiveTime>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                code="55561003" codeSystem="2.16.840.1.113883.6.96"
+                                                displayName="Active" xsi:type="CE" />
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship inversionInd="true" typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.64" />
+                                    <code code="48767-8" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC" />
+                                    <text>
+                                        <reference value="#problem14comment" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" />
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.3" />
+                            <id extension="35774-concern"
+                                root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass" displayName="Concern" />
+                            <text>
+                                <reference value="#problem15" />
+                            </text>
+                            <statusCode code="active" />
+                            <effectiveTime>
+                                <low value="20190429" />
+                            </effectiveTime>
+                            <entryRelationship inversionInd="false" typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.4" />
+                                    <id extension="35774"
+                                        root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                                    <code code="64572001" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75323-6"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC" />
+                                    </code>
+                                    <text>
+                                        <reference value="#problem15name" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime>
+                                        <low value="20190429" />
+                                    </effectiveTime>
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        code="1003722009" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#problem15name" />
+                                        </originalText>
+                                        <translation code="M25.569"
+                                            codeSystem="2.16.840.1.113883.6.90"
+                                            codeSystemName="ICD10" displayName="Knee pain" />
+                                        <translation code="719.46"
+                                            codeSystem="2.16.840.1.113883.6.103"
+                                            codeSystemName="ICD9" displayName="Knee pain" />
+                                        <translation code="78845"
+                                            codeSystem="2.16.840.1.113883.3.247.1.1"
+                                            codeSystemName="Intelligent Medical Objects ProblemIT"
+                                            displayName="Knee pain" />
+                                    </value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId extension="2019-10-01"
+                                            root="2.16.840.1.113883.10.20.22.5.6" />
+                                        <time value="20190429130759-0700" />
+                                        <assignedAuthor>
+                                            <id extension="534680415"
+                                                root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                            <id root="2.16.840.1.113883.4.6" />
+                                            <code nullFlavor="OTH">
+                                                <originalText>Physical Therapy</originalText>
+                                                <translation code="87"
+                                                    codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4160"
+                                                    codeSystemName="Epic.DXC.StandardProviderSpecialtyType"
+                                                    displayName="Physical Therapy" />
+                                                <translation code="34"
+                                                    codeSystem="1.2.840.114350.1.13.297.3.7.10.836982.1050"
+                                                    codeSystemName="Epic.SER.ProviderSpecialty"
+                                                    displayName="Physical Therapy" />
+                                            </code>
+                                            <telecom nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <id extension="50"
+                                                    root="1.2.840.114350.1.13.297.3.7.2.696570" />
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.2" />
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.6" />
+                                                <name>Providence California</name>
+                                                <telecom use="WP" value="tel:+1-855-415-6179" />
+                                                <addr use="WP">
+                                                    <streetAddressLine>4733 TORRANCE BLVD #4400</streetAddressLine>
+                                                    <county>LOS ANGELES</county>
+                                                    <city>TORRANCE</city>
+                                                    <state>CA</state>
+                                                    <postalCode>90503</postalCode>
+                                                    <country>USA</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6" />
+                                            <code code="33999-4" codeSystem="2.16.840.1.113883.6.1"
+                                                displayName="Status" />
+                                            <statusCode code="completed" />
+                                            <effectiveTime>
+                                                <low value="20190429" />
+                                            </effectiveTime>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                code="55561003" codeSystem="2.16.840.1.113883.6.96"
+                                                displayName="Active" xsi:type="CE" />
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" />
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.3" />
+                            <id extension="57636-concern"
+                                root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass" displayName="Concern" />
+                            <text>
+                                <reference value="#problem16" />
+                            </text>
+                            <statusCode code="active" />
+                            <effectiveTime>
+                                <low value="20201110" />
+                            </effectiveTime>
+                            <entryRelationship inversionInd="false" typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.4" />
+                                    <id extension="57636"
+                                        root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                                    <code code="64572001" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75323-6"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC" />
+                                    </code>
+                                    <text>
+                                        <reference value="#problem16name" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime>
+                                        <low value="20201110" />
+                                    </effectiveTime>
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        code="48694002" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#problem16name" />
+                                        </originalText>
+                                        <translation code="F41.9"
+                                            codeSystem="2.16.840.1.113883.6.90"
+                                            codeSystemName="ICD10" displayName="Anxiety" />
+                                        <translation code="300.00"
+                                            codeSystem="2.16.840.1.113883.6.103"
+                                            codeSystemName="ICD9" displayName="Anxiety" />
+                                        <translation code="38413"
+                                            codeSystem="2.16.840.1.113883.3.247.1.1"
+                                            codeSystemName="Intelligent Medical Objects ProblemIT"
+                                            displayName="Anxiety" />
+                                    </value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId extension="2019-10-01"
+                                            root="2.16.840.1.113883.10.20.22.5.6" />
+                                        <time value="20201110152854-0800" />
+                                        <assignedAuthor>
+                                            <id extension="326306730"
+                                                root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                            <id root="2.16.840.1.113883.4.6" />
+                                            <code code="207Q00000X"
+                                                codeSystem="2.16.840.1.113883.6.101"
+                                                displayName="Family Medicine">
+                                                <originalText>Family Medicine</originalText>
+                                                <translation code="19"
+                                                    codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4160"
+                                                    codeSystemName="Epic.DXC.StandardProviderSpecialtyType"
+                                                    displayName="Family Medicine" />
+                                                <translation code="9"
+                                                    codeSystem="1.2.840.114350.1.13.297.3.7.10.836982.1050"
+                                                    codeSystemName="Epic.SER.ProviderSpecialty"
+                                                    displayName="Family Medicine" />
+                                            </code>
+                                            <telecom nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <id extension="50"
+                                                    root="1.2.840.114350.1.13.297.3.7.2.696570" />
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.2" />
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.6" />
+                                                <name>Providence California</name>
+                                                <telecom use="WP" value="tel:+1-855-415-6179" />
+                                                <addr use="WP">
+                                                    <streetAddressLine>4733 TORRANCE BLVD #4400</streetAddressLine>
+                                                    <county>LOS ANGELES</county>
+                                                    <city>TORRANCE</city>
+                                                    <state>CA</state>
+                                                    <postalCode>90503</postalCode>
+                                                    <country>USA</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6" />
+                                            <code code="33999-4" codeSystem="2.16.840.1.113883.6.1"
+                                                displayName="Status" />
+                                            <statusCode code="completed" />
+                                            <effectiveTime>
+                                                <low value="20201110" />
+                                            </effectiveTime>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                code="55561003" codeSystem="2.16.840.1.113883.6.96"
+                                                displayName="Active" xsi:type="CE" />
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" />
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.3" />
+                            <id extension="57637-concern"
+                                root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass" displayName="Concern" />
+                            <text>
+                                <reference value="#problem17" />
+                            </text>
+                            <statusCode code="active" />
+                            <effectiveTime>
+                                <low value="20201110" />
+                            </effectiveTime>
+                            <entryRelationship inversionInd="false" typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.4" />
+                                    <id extension="57637"
+                                        root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                                    <code code="64572001" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75323-6"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC" />
+                                    </code>
+                                    <text>
+                                        <reference value="#problem17name" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime>
+                                        <low value="20201110" />
+                                    </effectiveTime>
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        code="195967001" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#problem17name" />
+                                        </originalText>
+                                        <translation code="J45.909"
+                                            codeSystem="2.16.840.1.113883.6.90"
+                                            codeSystemName="ICD10" displayName="Asthma" />
+                                        <translation code="493.90"
+                                            codeSystem="2.16.840.1.113883.6.103"
+                                            codeSystemName="ICD9" displayName="Asthma" />
+                                        <translation code="94262"
+                                            codeSystem="2.16.840.1.113883.3.247.1.1"
+                                            codeSystemName="Intelligent Medical Objects ProblemIT"
+                                            displayName="Asthma" />
+                                    </value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId extension="2019-10-01"
+                                            root="2.16.840.1.113883.10.20.22.5.6" />
+                                        <time value="20201110152910-0800" />
+                                        <assignedAuthor>
+                                            <id extension="326306730"
+                                                root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                            <id root="2.16.840.1.113883.4.6" />
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6" />
+                                            <code code="33999-4" codeSystem="2.16.840.1.113883.6.1"
+                                                displayName="Status" />
+                                            <statusCode code="completed" />
+                                            <effectiveTime>
+                                                <low value="20201110" />
+                                            </effectiveTime>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                code="55561003" codeSystem="2.16.840.1.113883.6.96"
+                                                displayName="Active" xsi:type="CE" />
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" />
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.3" />
+                            <id extension="58351-concern"
+                                root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass" displayName="Concern" />
+                            <text>
+                                <reference value="#problem18" />
+                            </text>
+                            <statusCode code="active" />
+                            <effectiveTime>
+                                <low value="20201116" />
+                            </effectiveTime>
+                            <entryRelationship inversionInd="false" typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.4" />
+                                    <id extension="58351"
+                                        root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                                    <code code="64572001" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75323-6"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC" />
+                                    </code>
+                                    <text>
+                                        <reference value="#problem18name" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime>
+                                        <low value="20201116" />
+                                    </effectiveTime>
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        code="239792003" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#problem18name" />
+                                        </originalText>
+                                        <translation code="M06.00"
+                                            codeSystem="2.16.840.1.113883.6.90"
+                                            codeSystemName="ICD10"
+                                            displayName="Rheumatoid arthritis with negative rheumatoid factor" />
+                                        <translation code="714.0"
+                                            codeSystem="2.16.840.1.113883.6.103"
+                                            codeSystemName="ICD9"
+                                            displayName="Rheumatoid arthritis with negative rheumatoid factor" />
+                                        <translation code="61725782"
+                                            codeSystem="2.16.840.1.113883.3.247.1.1"
+                                            codeSystemName="Intelligent Medical Objects ProblemIT"
+                                            displayName="Rheumatoid arthritis with negative rheumatoid factor" />
+                                    </value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId extension="2019-10-01"
+                                            root="2.16.840.1.113883.10.20.22.5.6" />
+                                        <time value="20201116181746-0800" />
+                                        <assignedAuthor>
+                                            <id extension="326306730"
+                                                root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                            <id root="2.16.840.1.113883.4.6" />
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6" />
+                                            <code code="33999-4" codeSystem="2.16.840.1.113883.6.1"
+                                                displayName="Status" />
+                                            <statusCode code="completed" />
+                                            <effectiveTime>
+                                                <low value="20201116" />
+                                            </effectiveTime>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                code="55561003" codeSystem="2.16.840.1.113883.6.96"
+                                                displayName="Active" xsi:type="CE" />
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" />
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.3" />
+                            <id extension="58352-concern"
+                                root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass" displayName="Concern" />
+                            <text>
+                                <reference value="#problem19" />
+                            </text>
+                            <statusCode code="active" />
+                            <effectiveTime>
+                                <low value="20201116" />
+                            </effectiveTime>
+                            <entryRelationship inversionInd="false" typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.4" />
+                                    <id extension="58352"
+                                        root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                                    <code code="64572001" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75323-6"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC" />
+                                    </code>
+                                    <text>
+                                        <reference value="#problem19name" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime>
+                                        <low value="20201116" />
+                                    </effectiveTime>
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        code="12247731000119102" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#problem19name" />
+                                        </originalText>
+                                        <translation code="M25.571"
+                                            codeSystem="2.16.840.1.113883.6.90"
+                                            codeSystemName="ICD10"
+                                            displayName="Arthralgia of both ankles" />
+                                        <translation code="719.47"
+                                            codeSystem="2.16.840.1.113883.6.103"
+                                            codeSystemName="ICD9"
+                                            displayName="Arthralgia of both ankles" />
+                                        <translation code="50984401"
+                                            codeSystem="2.16.840.1.113883.3.247.1.1"
+                                            codeSystemName="Intelligent Medical Objects ProblemIT"
+                                            displayName="Arthralgia of both ankles" />
+                                    </value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId extension="2019-10-01"
+                                            root="2.16.840.1.113883.10.20.22.5.6" />
+                                        <time value="20201116181747-0800" />
+                                        <assignedAuthor>
+                                            <id extension="326306730"
+                                                root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                            <id root="2.16.840.1.113883.4.6" />
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6" />
+                                            <code code="33999-4" codeSystem="2.16.840.1.113883.6.1"
+                                                displayName="Status" />
+                                            <statusCode code="completed" />
+                                            <effectiveTime>
+                                                <low value="20201116" />
+                                            </effectiveTime>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                code="55561003" codeSystem="2.16.840.1.113883.6.96"
+                                                displayName="Active" xsi:type="CE" />
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" />
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.3" />
+                            <id extension="58701-concern"
+                                root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass" displayName="Concern" />
+                            <text>
+                                <reference value="#problem20" />
+                            </text>
+                            <statusCode code="active" />
+                            <effectiveTime>
+                                <low value="20201119" />
+                            </effectiveTime>
+                            <entryRelationship inversionInd="false" typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.4" />
+                                    <id extension="58701"
+                                        root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                                    <code code="64572001" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75323-6"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC" />
+                                    </code>
+                                    <text>
+                                        <reference value="#problem20name" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime>
+                                        <low value="20201119" />
+                                    </effectiveTime>
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        code="371596008" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#problem20name" />
+                                        </originalText>
+                                        <translation code="F31.9"
+                                            codeSystem="2.16.840.1.113883.6.90"
+                                            codeSystemName="ICD10" displayName="Bipolar I disorder" />
+                                        <translation code="296.7"
+                                            codeSystem="2.16.840.1.113883.6.103"
+                                            codeSystemName="ICD9" displayName="Bipolar I disorder" />
+                                        <translation code="700699"
+                                            codeSystem="2.16.840.1.113883.3.247.1.1"
+                                            codeSystemName="Intelligent Medical Objects ProblemIT"
+                                            displayName="Bipolar I disorder" />
+                                    </value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId extension="2019-10-01"
+                                            root="2.16.840.1.113883.10.20.22.5.6" />
+                                        <time value="20201119123947-0800" />
+                                        <assignedAuthor>
+                                            <id extension="326306730"
+                                                root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                            <id root="2.16.840.1.113883.4.6" />
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6" />
+                                            <code code="33999-4" codeSystem="2.16.840.1.113883.6.1"
+                                                displayName="Status" />
+                                            <statusCode code="completed" />
+                                            <effectiveTime>
+                                                <low value="20201119" />
+                                            </effectiveTime>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                code="55561003" codeSystem="2.16.840.1.113883.6.96"
+                                                displayName="Active" xsi:type="CE" />
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" />
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.3" />
+                            <id extension="58702-concern"
+                                root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass" displayName="Concern" />
+                            <text>
+                                <reference value="#problem21" />
+                            </text>
+                            <statusCode code="active" />
+                            <effectiveTime>
+                                <low value="20201119" />
+                            </effectiveTime>
+                            <entryRelationship inversionInd="false" typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.4" />
+                                    <id extension="58702"
+                                        root="1.2.840.114350.1.13.297.3.7.2.768076" />
+                                    <code code="64572001" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75323-6"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC" />
+                                    </code>
+                                    <text>
+                                        <reference value="#problem21name" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime>
+                                        <low value="20201119" />
+                                    </effectiveTime>
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        code="87414006" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#problem21name" />
+                                        </originalText>
+                                        <translation code="F32.9"
+                                            codeSystem="2.16.840.1.113883.6.90"
+                                            codeSystemName="ICD10" displayName="Reactive depression" />
+                                        <translation code="300.4"
+                                            codeSystem="2.16.840.1.113883.6.103"
+                                            codeSystemName="ICD9" displayName="Reactive depression" />
+                                        <translation code="41752"
+                                            codeSystem="2.16.840.1.113883.3.247.1.1"
+                                            codeSystemName="Intelligent Medical Objects ProblemIT"
+                                            displayName="Reactive depression" />
+                                    </value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId extension="2019-10-01"
+                                            root="2.16.840.1.113883.10.20.22.5.6" />
+                                        <time value="20201119123950-0800" />
+                                        <assignedAuthor>
+                                            <id extension="326306730"
+                                                root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                            <id root="2.16.840.1.113883.4.6" />
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6" />
+                                            <code code="33999-4" codeSystem="2.16.840.1.113883.6.1"
+                                                displayName="Status" />
+                                            <statusCode code="completed" />
+                                            <effectiveTime>
+                                                <low value="20201119" />
+                                            </effectiveTime>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                code="55561003" codeSystem="2.16.840.1.113883.6.96"
+                                                displayName="Active" xsi:type="CE" />
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.12" />
+                    <code code="29299-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="REASON FOR VISIT" />
+                    <title>Reason for Visit</title>
+                    <text>
+                        <content ID="nof22">Not on file</content>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3" />
+                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.3" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3.1" />
+                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.3.1" />
+                    <id root="A87B29AA-3F70-11ED-9549-C301D81100B2" />
+                    <code code="30954-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="Relevant diagnostic tests/laboratory data Narrative" />
+                    <title>Results</title>
+                    <text>
+                        <list styleCode="xTOC">
+                            <item ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845">
+                                <caption
+                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Procedure">Stool
+                                    Pathogens, NAAT, 12 to 25 Targets (09/28/2022 1:51 PM PDT)</caption>
+                                <table>
+                                    <colgroup>
+                                        <col width="20%" />
+                                        <col width="12%" />
+                                        <col width="8%" />
+                                        <col width="20%" />
+                                        <col span="2" width="10%" />
+                                        <col width="20%" />
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th>Component</th>
+                                            <th>Value</th>
+                                            <th>Ref Range</th>
+                                            <th>Test Method</th>
+                                            <th>Analysis Time</th>
+                                            <th>Performed At</th>
+                                            <th>Pathologist Signature</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp1"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp1Name">Campylobacter,
+                                                NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp1TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp1Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp2"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp2Name">Plesiomonas
+                                                shigelloides, NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp2TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp2Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp3"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp3Name">Salmonella,
+                                                NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp3TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp3Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp4"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp4Name">Vibrio,
+                                                NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp4TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp4Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp5"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp5Name">Vibrio
+                                                cholerae, NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp5TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp5Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp6"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp6Name">Yersinia
+                                                enterocolitica, NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp6TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp6Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp7"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp7Name">E.
+                                                Coli (EAEC), NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp7TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp7Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp8"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp8Name">E.
+                                                Coli (EPEC), NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp8TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp8Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp9"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp9Name">E.
+                                                Coli (ETEC), NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp9TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp9Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp10"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp10Name">Shiga-Like
+                                                Toxin E. Coli (STEC), NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp10TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp10Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp11"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp11Name">Shigella/EIEC,
+                                                NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp11TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp11Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp12"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp12Name">Cryptosporidium,
+                                                NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp12TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp12Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp13"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp13Name">Cyclospora
+                                                cayetanensis, NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp13TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp13Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp14"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp14Name">E.
+                                                histolytica, NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp14TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp14Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp15"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp15Name">Giardia
+                                                lamblia, NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp15TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp15Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp16"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp16Name">Adenovirus
+                                                F 40/41, NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp16TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp16Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp17"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp17Name">Astrovirus,
+                                                NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp17TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp17Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp18"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp18Name">Norovirus,
+                                                NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp18TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp18Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp19"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp19Name">Rotavirus
+                                                A, NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp19TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp19Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp20"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp20Name">Sapovirus,
+                                                NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp20TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 1:59 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp20Signature" />
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                <table>
+                                    <colgroup>
+                                        <col span="5" width="20%" />
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th>Specimen (Source)</th>
+                                            <th>Anatomical Location / Laterality</th>
+                                            <th>Collection Method / Volume</th>
+                                            <th>Collection Time</th>
+                                            <th>Received Time</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Specimen">
+                                                Stool</td>
+                                            <td>STOOL SPECIMEN / Unknown</td>
+                                            <td />
+                                            <td>09/28/2022 1:51 PM PDT</td>
+                                            <td>09/28/2022 1:51 PM PDT</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                <table>
+                                    <colgroup>
+                                        <col width="20%" />
+                                        <col width="80%" />
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th>Authorizing Provider</th>
+                                            <th>Result Type</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>Ambhp1 Test MD</td>
+                                            <td>MICROBIOLOGY - GENERAL ORDERABLES</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                <table>
+                                    <colgroup>
+                                        <col span="3" width="20%" />
+                                        <col width="40%" />
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th>Performing Organization</th>
+                                            <th>Address</th>
+                                            <th>City/State/ZIP Code</th>
+                                            <th>Phone Number</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.PerformingLab">
+                                                <paragraph>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</paragraph>
+                                            </td>
+                                            <td>
+                                                <paragraph>501 S. Buena Vista Street</paragraph>
+                                            </td>
+                                            <td>
+                                                <paragraph>Burbank, CA 91505</paragraph>
+                                            </td>
+                                            <td>
+                                                <paragraph>818-847-6000</paragraph>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </item>
+                            <item ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844">
+                                <caption
+                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Procedure"
+                                    styleCode="xAbnormal">(ABNORMAL) Stool Pathogens, NAAT, 12 to 25
+                                    Targets (09/28/2022 1:51 PM PDT)</caption>
+                                <table>
+                                    <colgroup>
+                                        <col width="20%" />
+                                        <col width="12%" />
+                                        <col width="8%" />
+                                        <col width="20%" />
+                                        <col span="2" width="10%" />
+                                        <col width="20%" />
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th>Component</th>
+                                            <th>Value</th>
+                                            <th>Ref Range</th>
+                                            <th>Test Method</th>
+                                            <th>Analysis Time</th>
+                                            <th>Performed At</th>
+                                            <th>Pathologist Signature</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp1"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp1Name">Campylobacter,
+                                                NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp1TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp1Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp2"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp2Name">Plesiomonas
+                                                shigelloides, NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp2TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp2Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp3"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp3Name">Salmonella,
+                                                NAAT</td>
+                                            <td>
+                                                <content styleCode="xflagData">DETECTED</content>
+                                                <content styleCode="xflagData"> (AA)</content>
+                                            </td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp3TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp3Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp4"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp4Name">Vibrio,
+                                                NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp4TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp4Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp5"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp5Name">Vibrio
+                                                cholerae, NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp5TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp5Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp6"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp6Name">Yersinia
+                                                enterocolitica, NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp6TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp6Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp7"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp7Name">E.
+                                                Coli O157, NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp7TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp7Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp8"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp8Name">E.
+                                                Coli (EAEC), NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp8TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp8Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp9"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp9Name">E.
+                                                Coli (EPEC), NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp9TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp9Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp10"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp10Name">E.
+                                                Coli (ETEC), NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp10TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp10Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp11"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp11Name">Shiga-Like
+                                                Toxin E. Coli (STEC), NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp11TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp11Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp12"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp12Name">Shigella/EIEC,
+                                                NAAT</td>
+                                            <td>
+                                                <content styleCode="xflagData">DETECTED</content>
+                                                <content styleCode="xflagData"> (AA)</content>
+                                            </td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp12TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp12Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp13"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp13Name">Cryptosporidium,
+                                                NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp13TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp13Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp14"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp14Name">Cyclospora
+                                                cayetanensis, NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp14TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp14Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp15"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp15Name">E.
+                                                histolytica, NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp15TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp15Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp16"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp16Name">Giardia
+                                                lamblia, NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp16TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp16Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp17"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp17Name">Adenovirus
+                                                F 40/41, NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp17TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp17Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp18"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp18Name">Astrovirus,
+                                                NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp18TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp18Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp19"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp19Name">Norovirus,
+                                                NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp19TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp19Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp20"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp20Name">Rotavirus
+                                                A, NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp20TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp20Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp21"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp21Name">Sapovirus,
+                                                NAAT</td>
+                                            <td>Not Detected</td>
+                                            <td>Not Detected</td>
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp21TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp21Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp22"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp22Name">GI
+                                                Pathogens Panel</td>
+                                            <td>Acceptable</td>
+                                            <td />
+                                            <td>
+                                                <paragraph
+                                                    ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp22TestMethodName1">LAB
+                                                    DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph>
+                                            </td>
+                                            <td>09/28/2022 2:00 PM PDT</td>
+                                            <td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY
+                                                (CLIA 05D0672675)</td>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp22Signature" />
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                <table>
+                                    <colgroup>
+                                        <col span="5" width="20%" />
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th>Specimen (Source)</th>
+                                            <th>Anatomical Location / Laterality</th>
+                                            <th>Collection Method / Volume</th>
+                                            <th>Collection Time</th>
+                                            <th>Received Time</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Specimen">
+                                                Stool</td>
+                                            <td>STOOL SPECIMEN / Unknown</td>
+                                            <td />
+                                            <td>09/28/2022 1:51 PM PDT</td>
+                                            <td>09/28/2022 1:51 PM PDT</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                <table>
+                                    <colgroup>
+                                        <col width="20%" />
+                                        <col width="80%" />
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th>Authorizing Provider</th>
+                                            <th>Result Type</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>Ambhp1 Test MD</td>
+                                            <td>MICROBIOLOGY - GENERAL ORDERABLES</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                <table>
+                                    <colgroup>
+                                        <col span="3" width="20%" />
+                                        <col width="40%" />
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th>Performing Organization</th>
+                                            <th>Address</th>
+                                            <th>City/State/ZIP Code</th>
+                                            <th>Phone Number</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.PerformingLab">
+                                                <paragraph>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</paragraph>
+                                            </td>
+                                            <td>
+                                                <paragraph>501 S. Buena Vista Street</paragraph>
+                                            </td>
+                                            <td>
+                                                <paragraph>Burbank, CA 91505</paragraph>
+                                            </td>
+                                            <td>
+                                                <paragraph>818-847-6000</paragraph>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </item>
+                        </list>
+                        <footnote ID="subTitle23" styleCode="xSectionSubTitle">documented in this
+                            encounter</footnote>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="BATTERY" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1" />
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.1" />
+                            <id extension="1670844" root="1.2.840.114350.1.13.297.3.7.2.798268" />
+                            <code code="79381-0" codeSystem="2.16.840.1.113883.6.1"
+                                codeSystemName="LOINC">
+                                <originalText>Stool Pathogens, NAAT, 12 to 25 Targets</originalText>
+                                <translation code="LAB10082" codeSystem="2.16.840.1.113883.6.12"
+                                    codeSystemName="CPT-4"
+                                    displayName="STOOL PATHOGENS, NAAT, 12 TO 25 TARGETS" />
+                                <translation code="139834"
+                                    codeSystem="1.2.840.114350.1.13.297.3.7.2.696580"
+                                    codeSystemName="Epic.EAP.ID"
+                                    displayName="Stool Pathogens, NAAT, 12 to 25 Targets" />
+                            </code>
+                            <statusCode code="completed" />
+                            <effectiveTime>
+                                <low value="20220928205100+0000" />
+                                <high value="20220928205100+0000" />
+                            </effectiveTime>
+                            <performer>
+                                <time value="20220928210053+0000" />
+                                <assignedEntity>
+                                    <id nullFlavor="UNK" />
+                                    <telecom nullFlavor="NA" />
+                                    <representedOrganization classCode="ORG"
+                                        determinerCode="INSTANCE">
+                                        <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA
+                                            05D0672675)</name>
+                                        <addr use="WP">
+                                            <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                            <city>Burbank</city>
+                                            <state>CA</state>
+                                            <postalCode>91505</postalCode>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId extension="2019-10-01"
+                                    root="2.16.840.1.113883.10.20.22.5.6" />
+                                <time value="20220928140053-0700" />
+                                <assignedAuthor>
+                                    <id extension="508635814"
+                                        root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                    <id extension="P512866"
+                                        root="1.2.840.114350.1.13.297.3.7.2.697780" />
+                                    <id nullFlavor="UNK" root="2.16.840.1.113883.4.6" />
+                                    <telecom nullFlavor="UNK" />
+                                    <representedOrganization>
+                                        <id extension="50"
+                                            root="1.2.840.114350.1.13.297.3.7.2.696570" />
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.2" />
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.6" />
+                                        <name>Providence California</name>
+                                        <telecom use="WP" value="tel:+1-855-415-6179" />
+                                        <addr use="WP">
+                                            <streetAddressLine>4733 TORRANCE BLVD #4400</streetAddressLine>
+                                            <county>LOS ANGELES</county>
+                                            <city>TORRANCE</city>
+                                            <state>CA</state>
+                                            <postalCode>90503</postalCode>
+                                            <country>USA</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id extension="urn:PHS:deployment.OCTST-CE"
+                                        root="1.2.840.114350.1.13.297.3.7.3.688879.110" />
+                                    <representedOrganization>
+                                        <name>Providence Health and Services Oregon and California
+                                            (TST)</name>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <participant typeCode="RESP">
+                                <participantRole classCode="PROV">
+                                    <id root="2.16.840.1.113883.4.6" />
+                                    <code nullFlavor="UNK">
+                                        <originalText>Endocrinology</originalText>
+                                        <translation code="18"
+                                            codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4160"
+                                            codeSystemName="Epic.DXC.StandardProviderSpecialtyType"
+                                            displayName="Endocrinology" />
+                                        <translation code="7"
+                                            codeSystem="1.2.840.114350.1.13.297.3.7.10.836982.1050"
+                                            codeSystemName="Epic.SER.ProviderSpecialty"
+                                            displayName="Endocrinology" />
+                                    </code>
+                                    <addr use="WP">
+                                        <streetAddressLine>2001 LIND AVE</streetAddressLine>
+                                        <city>RENTON</city>
+                                        <state>WA</state>
+                                        <postalCode>98059</postalCode>
+                                    </addr>
+                                    <telecom nullFlavor="UNK" />
+                                    <playingEntity classCode="PSN">
+                                        <name use="L">
+                                            <given>Ambhp1</given>
+                                            <family>Test</family>
+                                            <suffix qualifier="AC"> MD</suffix>
+                                            <validTime>
+                                                <low nullFlavor="UNK" />
+                                                <high nullFlavor="UNK" />
+                                            </validTime>
+                                        </name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <component>
+                                <procedure classCode="PROC" moodCode="EVN">
+                                    <code code="17636008" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"
+                                        displayName="Specimen collection (procedure)" />
+                                    <effectiveTime value="20220928205100+0000" />
+                                    <targetSiteCode code="119339001"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"
+                                        displayName="Stool specimen (specimen)">
+                                        <translation code="347"
+                                            codeSystem="1.2.840.114350.1.13.297.3.7.4.798268.325"
+                                            codeSystemName="Epic.Specimen" displayName="Stool" />
+                                    </targetSiteCode>
+                                    <participant typeCode="PRD">
+                                        <templateId root="1.2.840.114350.1.72.3.12" />
+                                        <participantRole classCode="SPEC">
+                                            <id extension="1670844"
+                                                root="1.2.840.114350.1.13.297.3.7.7.798268.300" />
+                                            <playingEntity>
+                                                <code code="119339001"
+                                                    codeSystem="2.16.840.1.113883.6.96"
+                                                    codeSystemName="SNOMED CT">
+                                                    <originalText>Stool</originalText>
+                                                    <translation code="54"
+                                                        codeSystem="1.2.840.114350.1.13.297.3.7.4.798268.300"
+                                                        codeSystemName="Epic.Specimen"
+                                                        displayName="Stool" />
+                                                </code>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <entryRelationship typeCode="COMP">
+                                        <act classCode="ACT" moodCode="EVN">
+                                            <templateId root="1.3.6.1.4.1.19376.1.3.1.3" />
+                                            <code code="SPRECEIVE"
+                                                codeSystem="1.3.5.1.4.1.19376.1.5.3.2"
+                                                codeSystemName="IHEActCode"
+                                                displayName="Specimen Receive" />
+                                            <effectiveTime value="20220928205136+0000" />
+                                        </act>
+                                    </entryRelationship>
+                                </procedure>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.1"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82196-7" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Campylobacter, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp1Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp1" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.2"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82198-3" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Plesiomonas shigelloides, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp2Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp2" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.3"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82199-1" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Salmonella, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp3Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp3" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        code="260373001" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>DETECTED</originalText>
+                                    </value>
+                                    <interpretationCode code="AA"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <originalText>Abnormal Alert</originalText>
+                                    </interpretationCode>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.4"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82200-7" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Vibrio, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp4Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp4" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.5"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82201-5" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Vibrio cholerae, NAAT
+                                          <reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp5Name" />
+                                        </originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp5" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.6"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82202-3" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Yersinia enterocolitica, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp6Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp6" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.7"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82204-9" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>E. Coli O157, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp7Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp7" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.8"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="80349-4" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>E. Coli (EAEC), NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp8Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp8" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.9"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="80348-6" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>E. Coli (EPEC), NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp9Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp9" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.10"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="80351-0" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>E. Coli (ETEC), NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp10Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp10" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2016-12-01"
+                                        root="2.16.840.1.113883.10.20.15.2.3.2" />
+                                    <id extension="1670844.11"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code xmlns:sdtc="urn:hl7-org:sdtc" code="82203-1"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        sdtc:valueSet="2.16.840.1.114222.4.11.7508"
+                                        sdtc:valueSetVersion="2022-01-12">
+                                        <originalText>Shiga-Like Toxin E. Coli (STEC), NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp11Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp11" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.12"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="80350-2" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Shigella/EIEC, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp12Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp12" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        code="260373001" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>DETECTED</originalText>
+                                    </value>
+                                    <interpretationCode code="AA"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <originalText>Abnormal Alert</originalText>
+                                    </interpretationCode>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.13"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82205-6" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Cryptosporidium, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp13Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp13" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.14"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82206-4" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Cyclospora cayetanensis, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp14Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp14" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.15"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82207-2" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>E. histolytica, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp15Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp15" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.16"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82208-0" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Giardia lamblia, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp16Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp16" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.17"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82209-8" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Adenovirus F 40/41, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp17Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp17" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.18"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82210-6" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Astrovirus, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp18Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp18" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.19"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82211-4" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Norovirus, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp19Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp19" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.20"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82212-2" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Rotavirus A, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp20Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp20" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.21"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82195-9" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Sapovirus, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp21Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp21" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670844.22"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        nullFlavor="UNK">
+                                        <originalText>GI Pathogens Panel<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp22Name" /></originalText>
+                                        <translation code="9435"
+                                            codeSystem="1.2.840.114350.1.13.297.3.7.2.768282"
+                                            codeSystemName="Epic.LRR.ID"
+                                            displayName="GI Pathogens Panel" />
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp22" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Acceptable</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId root="1.2.840.114350.1.72.3.3" />
+                                    <id extension="1670844"
+                                        root="1.2.840.114350.1.13.297.3.7.2.798268" />
+                                    <code code="56850-1" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Lab Interpretation</originalText>
+                                    </code>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Abnormal</value>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="1.2.840.114350.1.72.3.4" />
+                                    <id extension="1670844"
+                                        root="1.2.840.114350.1.13.297.3.7.2.798268" />
+                                    <code nullFlavor="UNK" />
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928210053+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        code="18" codeSystem="1.2.840.114350.1.72.1.5007"
+                                        codeSystemName="Epic.Result.Type" xsi:type="CD" />
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="BATTERY" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1" />
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.1" />
+                            <id extension="1670845" root="1.2.840.114350.1.13.297.3.7.2.798268" />
+                            <code code="79381-0" codeSystem="2.16.840.1.113883.6.1"
+                                codeSystemName="LOINC">
+                                <originalText>Stool Pathogens, NAAT, 12 to 25 Targets</originalText>
+                                <translation code="LAB10082" codeSystem="2.16.840.1.113883.6.12"
+                                    codeSystemName="CPT-4"
+                                    displayName="STOOL PATHOGENS, NAAT, 12 TO 25 TARGETS" />
+                                <translation code="139834"
+                                    codeSystem="1.2.840.114350.1.13.297.3.7.2.696580"
+                                    codeSystemName="Epic.EAP.ID"
+                                    displayName="Stool Pathogens, NAAT, 12 to 25 Targets" />
+                            </code>
+                            <statusCode code="completed" />
+                            <effectiveTime>
+                                <low value="20220928205100+0000" />
+                                <high value="20220928205100+0000" />
+                            </effectiveTime>
+                            <performer>
+                                <time value="20220928205943+0000" />
+                                <assignedEntity>
+                                    <id nullFlavor="UNK" />
+                                    <telecom nullFlavor="NA" />
+                                    <representedOrganization classCode="ORG"
+                                        determinerCode="INSTANCE">
+                                        <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA
+                                            05D0672675)</name>
+                                        <addr use="WP">
+                                            <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                            <city>Burbank</city>
+                                            <state>CA</state>
+                                            <postalCode>91505</postalCode>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId extension="2019-10-01"
+                                    root="2.16.840.1.113883.10.20.22.5.6" />
+                                <time value="20220928135943-0700" />
+                                <assignedAuthor>
+                                    <id extension="508635814"
+                                        root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                    <id extension="P512866"
+                                        root="1.2.840.114350.1.13.297.3.7.2.697780" />
+                                    <id nullFlavor="UNK" root="2.16.840.1.113883.4.6" />
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id extension="urn:PHS:deployment.OCTST-CE"
+                                        root="1.2.840.114350.1.13.297.3.7.3.688879.110" />
+                                    <representedOrganization>
+                                        <name>Providence Health and Services Oregon and California
+                                            (TST)</name>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <participant typeCode="RESP">
+                                <participantRole classCode="PROV">
+                                    <id root="2.16.840.1.113883.4.6" />
+                                    <code nullFlavor="UNK">
+                                        <originalText>Endocrinology</originalText>
+                                        <translation code="18"
+                                            codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4160"
+                                            codeSystemName="Epic.DXC.StandardProviderSpecialtyType"
+                                            displayName="Endocrinology" />
+                                        <translation code="7"
+                                            codeSystem="1.2.840.114350.1.13.297.3.7.10.836982.1050"
+                                            codeSystemName="Epic.SER.ProviderSpecialty"
+                                            displayName="Endocrinology" />
+                                    </code>
+                                    <addr use="WP">
+                                        <streetAddressLine>2001 LIND AVE</streetAddressLine>
+                                        <city>RENTON</city>
+                                        <state>WA</state>
+                                        <postalCode>98059</postalCode>
+                                    </addr>
+                                    <telecom nullFlavor="UNK" />
+                                    <playingEntity classCode="PSN">
+                                        <name use="L">
+                                            <given>Ambhp1</given>
+                                            <family>Test</family>
+                                            <suffix qualifier="AC"> MD</suffix>
+                                            <validTime>
+                                                <low nullFlavor="UNK" />
+                                                <high nullFlavor="UNK" />
+                                            </validTime>
+                                        </name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <component>
+                                <procedure classCode="PROC" moodCode="EVN">
+                                    <code code="17636008" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"
+                                        displayName="Specimen collection (procedure)" />
+                                    <effectiveTime value="20220928205100+0000" />
+                                    <targetSiteCode code="119339001"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"
+                                        displayName="Stool specimen (specimen)">
+                                        <translation code="347"
+                                            codeSystem="1.2.840.114350.1.13.297.3.7.4.798268.325"
+                                            codeSystemName="Epic.Specimen" displayName="Stool" />
+                                    </targetSiteCode>
+                                    <participant typeCode="PRD">
+                                        <templateId root="1.2.840.114350.1.72.3.12" />
+                                        <participantRole classCode="SPEC">
+                                            <id extension="1670845"
+                                                root="1.2.840.114350.1.13.297.3.7.7.798268.300" />
+                                            <playingEntity>
+                                                <code code="119339001"
+                                                    codeSystem="2.16.840.1.113883.6.96"
+                                                    codeSystemName="SNOMED CT">
+                                                    <originalText>Stool</originalText>
+                                                    <translation code="54"
+                                                        codeSystem="1.2.840.114350.1.13.297.3.7.4.798268.300"
+                                                        codeSystemName="Epic.Specimen"
+                                                        displayName="Stool" />
+                                                </code>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <entryRelationship typeCode="COMP">
+                                        <act classCode="ACT" moodCode="EVN">
+                                            <templateId root="1.3.6.1.4.1.19376.1.3.1.3" />
+                                            <code code="SPRECEIVE"
+                                                codeSystem="1.3.5.1.4.1.19376.1.5.3.2"
+                                                codeSystemName="IHEActCode"
+                                                displayName="Specimen Receive" />
+                                            <effectiveTime value="20220928205136+0000" />
+                                        </act>
+                                    </entryRelationship>
+                                </procedure>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.1"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82196-7" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Campylobacter, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp1Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp1" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.2"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82198-3" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Plesiomonas shigelloides, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp2Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp2" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.3"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82199-1" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Salmonella, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp3Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp3" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.4"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82200-7" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Vibrio, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp4Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp4" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.5"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82201-5" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Vibrio cholerae, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp5Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp5" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.6"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82202-3" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Yersinia enterocolitica, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp6Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp6" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.7"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="80349-4" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>E. Coli (EAEC), NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp7Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp7" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.8"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="80348-6" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>E. Coli (EPEC), NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp8Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp8" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.9"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="80351-0" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>E. Coli (ETEC), NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp9Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp9" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.10"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82203-1" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Shiga-Like Toxin E. Coli (STEC), NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp10Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp10" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.11"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="80350-2" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Shigella/EIEC, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp11Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp11" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.12"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82205-6" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Cryptosporidium, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp12Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp12" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.13"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82206-4" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Cyclospora cayetanensis, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp13Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp13" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.14"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82207-2" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>E. histolytica, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp14Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp14" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.15"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82208-0" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Giardia lamblia, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp15Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp15" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.16"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82209-8" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Adenovirus F 40/41, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp16Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp16" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.17"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82210-6" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Astrovirus, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp17Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp17" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.18"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82211-4" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Norovirus, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp18Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp18" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.19"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82212-2" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Rotavirus A, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp19Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp19" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <id extension="1670845.20"
+                                        root="1.2.840.114350.1.13.297.3.7.6.798268.2000" />
+                                    <code code="82195-9" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Sapovirus, NAAT<reference
+                                                value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp20Name" /></originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp20" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Not Detected</value>
+                                    <performer typeCode="PRF">
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <name>PROVIDENCE ST. JOSEPH MEDICAL CENTER
+                                                    LABORATORY (CLIA 05D0672675)</name>
+                                                <telecom value="tel:+1-818-847-6000" />
+                                                <addr>
+                                                    <streetAddressLine>501 S. Buena Vista Street</streetAddressLine>
+                                                    <city>Burbank</city>
+                                                    <state>CA</state>
+                                                    <postalCode>91505</postalCode>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="RESP">
+                                        <participantRole classCode="PROV">
+                                            <playingEntity classCode="PSN">
+                                                <name>
+                                                    <given>Kiran</given>
+                                                    <given>B</given>
+                                                    <family>Qidwai</family>
+                                                </name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Not Detected</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ST">Not Detected</value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId extension="2015-08-01"
+                                        root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId root="1.2.840.114350.1.72.3.3" />
+                                    <id extension="1670845"
+                                        root="1.2.840.114350.1.13.297.3.7.2.798268" />
+                                    <code code="56850-1" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>Lab Interpretation</originalText>
+                                    </code>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="ST">Normal</value>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="1.2.840.114350.1.72.3.4" />
+                                    <id extension="1670845"
+                                        root="1.2.840.114350.1.13.297.3.7.2.798268" />
+                                    <code nullFlavor="UNK" />
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="20220928205943+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        code="18" codeSystem="1.2.840.114350.1.72.1.5007"
+                                        codeSystemName="Epic.Result.Type" xsi:type="CD" />
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.17" />
+                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.17" />
+                    <code code="29762-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="Social history Narrative" />
+                    <title>Social History</title>
+                    <text>
+                        <table ID="sochist25">
+                            <colgroup>
+                                <col span="2" width="25%" />
+                                <col width="13%" />
+                                <col width="12%" />
+                                <col width="25%" />
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Tobacco Use</th>
+                                    <th>Types</th>
+                                    <th>Packs/Day</th>
+                                    <th>Years Used</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>Smoking Tobacco: Never</td>
+                                    <td />
+                                    <td ID="sochist25packsperday" />
+                                    <td />
+                                    <td />
+                                </tr>
+                                <tr ID="sochist25smokeless" styleCode="xRowAlt">
+                                    <td>Smokeless Tobacco: Never</td>
+                                    <td />
+                                    <td />
+                                    <td />
+                                    <td />
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table>
+                            <colgroup>
+                                <col span="2" width="25%" />
+                                <col width="50%" />
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Alcohol Use</th>
+                                    <th>Standard Drinks/Week</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td ID="alcoholStatus">Yes</td>
+                                    <td>0 (1 standard drink = 0.6 oz pure alcohol)</td>
+                                    <td />
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table>
+                            <colgroup>
+                                <col width="25%" />
+                                <col width="75%" />
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Sex Assigned at Birth</th>
+                                    <th>Date Recorded</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr ID="BirthSex26">
+                                    <td ID="BirthSex26Value">Not on file</td>
+                                    <td />
+                                </tr>
+                            </tbody>
+                        </table>
+                        <footnote ID="subTitle24" styleCode="xSectionSubTitle">documented as of this
+                            encounter</footnote>
+                    </text>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78" />
+                            <templateId extension="2014-06-09"
+                                root="2.16.840.1.113883.10.20.22.4.78" />
+                            <id extension="Z41472^^72166-2"
+                                root="1.2.840.114350.1.13.297.3.7.1.1040.1" />
+                            <code code="72166-2" codeSystem="2.16.840.1.113883.6.1"
+                                codeSystemName="LOINC" displayName="Tobacco smoking status NHIS" />
+                            <text>
+                                <reference value="#sochist25" />
+                            </text>
+                            <statusCode code="completed" />
+                            <effectiveTime value="20190416" />
+                            <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                code="266919005" codeSystem="2.16.840.1.113883.6.96"
+                                codeSystemName="SNOMED CT" displayName="Never smoked tobacco"
+                                xsi:type="CD" />
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId extension="2019-10-01"
+                                    root="2.16.840.1.113883.10.20.22.5.6" />
+                                <time value="20190416" />
+                                <assignedAuthor>
+                                    <id extension="195858804"
+                                        root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                    <id root="2.16.840.1.113883.4.6" />
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId extension="2019-10-01"
+                                    root="2.16.840.1.113883.10.20.22.5.6" />
+                                <time value="20220216" />
+                                <assignedAuthor>
+                                    <id extension="326310445"
+                                        root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                    <id root="2.16.840.1.113883.4.6" />
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38" />
+                            <templateId extension="2015-08-01"
+                                root="2.16.840.1.113883.10.20.22.4.38" />
+                            <id extension="Z41472^^713914004"
+                                root="1.2.840.114350.1.13.297.3.7.1.1040.8" />
+                            <code code="229819007" codeSystem="2.16.840.1.113883.6.96"
+                                codeSystemName="SNOMED-CT" displayName="Tobacco use and exposure">
+                                <translation code="88031-0" codeSystem="2.16.840.1.113883.6.1"
+                                    codeSystemName="LOINC" displayName="Smokeless tobacco status" />
+                            </code>
+                            <text>
+                                <reference value="#sochist25smokeless" />
+                            </text>
+                            <statusCode code="completed" />
+                            <effectiveTime value="20190416" />
+                            <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                code="451381000124107" codeSystem="2.16.840.1.113883.6.96"
+                                codeSystemName="SNOMED CT" displayName="Smokeless tobacco non-user"
+                                xsi:type="CD" />
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId extension="2019-10-01"
+                                    root="2.16.840.1.113883.10.20.22.5.6" />
+                                <time value="20190416" />
+                                <assignedAuthor>
+                                    <id extension="195858804"
+                                        root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                    <id root="2.16.840.1.113883.4.6" />
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId extension="2019-10-01"
+                                    root="2.16.840.1.113883.10.20.22.5.6" />
+                                <time value="20220216" />
+                                <assignedAuthor>
+                                    <id extension="326310445"
+                                        root="1.2.840.114350.1.13.297.3.7.1.1133" />
+                                    <id root="2.16.840.1.113883.4.6" />
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38" />
+                            <templateId extension="2015-08-01"
+                                root="2.16.840.1.113883.10.20.22.4.38" />
+                            <id extension="Z41472^55374.98^160573003"
+                                root="1.2.840.114350.1.13.297.3.7.1.1040.12" />
+                            <code code="160573003" codeSystem="2.16.840.1.113883.6.96"
+                                codeSystemName="SNOMED CT" displayName="Alcohol intake">
+                                <translation code="11331-6" codeSystem="2.16.840.1.113883.6.1"
+                                    codeSystemName="LOINC" displayName="History of Alcohol Use" />
+                            </code>
+                            <statusCode code="completed" />
+                            <effectiveTime value="20220216" />
+                            <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                code="219006" codeSystem="2.16.840.1.113883.6.96"
+                                codeSystemName="SNOMED CT"
+                                displayName="Current drinker of alcohol (finding)" xsi:type="CD">
+                                <originalText>
+                                    <reference value="#alcoholStatus" />
+                                </originalText>
+                            </value>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId extension="2016-06-01"
+                                root="2.16.840.1.113883.10.20.22.4.200" />
+                            <id extension="Z41472" root="1.2.840.114350.1.13.297.3.7.1.1040.20" />
+                            <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                codeSystemName="LOINC" displayName="Sex Assigned At Birth" />
+                            <text>
+                                <reference value="#BirthSex26" />
+                            </text>
+                            <statusCode code="completed" />
+                            <effectiveTime value="19700101" />
+                            <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                codeSystem="2.16.840.1.113883.5.1" nullFlavor="UNK" xsi:type="CD">
+                                <originalText>
+                                    <reference value="#BirthSex26Value" />
+                                </originalText>
+                            </value>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22" />
+                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.22" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22.1" />
+                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.22.1" />
+                    <code code="46240-8" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="History of Hospitalizations+Outpatient visits Narrative" />
+                    <title>Encounter Details</title>
+                    <text>
+                        <table>
+                            <colgroup>
+                                <col width="10%" />
+                                <col width="15%" />
+                                <col span="3" width="25%" />
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Type</th>
+                                    <th>Department</th>
+                                    <th>Care Team</th>
+                                    <th>Description</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr ID="encounter27" styleCode="xRowNormal">
+                                    <td>9/28/22</td>
+                                    <td ID="encounter27type">Lab Requisition</td>
+                                    <td>
+                                        <paragraph>PROVIDENCE ST JOSEPH MED CTR LABORATORY</paragraph>
+                                        <paragraph>501 S Buena Vista St</paragraph>
+                                        <paragraph>Burbank, CA 91505-4809</paragraph>
+                                        <paragraph>818-847-6060</paragraph>
+                                    </td>
+                                    <td>
+                                        <paragraph styleCode="Bold">Test, Ambhp1, MD</paragraph>
+                                        <paragraph>2001 LIND AVE</paragraph>
+                                        <paragraph>RENTON, WA 98059</paragraph>
+                                    </td>
+                                    <td />
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49" />
+                            <templateId extension="2015-08-01"
+                                root="2.16.840.1.113883.10.20.22.4.49" />
+                            <id assigningAuthorityName="EPIC" extension="50000595021"
+                                root="1.2.840.114350.1.13.297.3.7.3.698084.8" />
+                            <code code="AMB" codeSystem="2.16.840.1.113883.5.4">
+                                <originalText>
+                                    <reference value="#encounter27type" />
+                                </originalText>
+                                <translation code="100"
+                                    codeSystem="1.2.840.114350.1.13.297.3.7.4.698084.30"
+                                    codeSystemName="Epic.EncounterType" />
+                                <translation code="100" codeSystem="1.2.840.114350.1.72.1.30" />
+                                <translation code="4" codeSystem="1.2.840.114350.1.72.1.30.1" />
+                            </code>
+                            <text>
+                                <reference value="#encounter27" />
+                            </text>
+                            <statusCode code="normal" />
+                            <effectiveTime value="20220928" />
+                            <performer typeCode="PRF">
+                                <time>
+                                    <low nullFlavor="UNK" />
+                                    <high nullFlavor="UNK" />
+                                </time>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK" root="2.16.840.1.113883.4.6" />
+                                    <code nullFlavor="OTH">
+                                        <originalText>Endocrinology</originalText>
+                                        <translation code="18"
+                                            codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4160"
+                                            codeSystemName="Epic.DXC.StandardProviderSpecialtyType"
+                                            displayName="Endocrinology" />
+                                        <translation code="7"
+                                            codeSystem="1.2.840.114350.1.13.297.3.7.10.836982.1050"
+                                            codeSystemName="Epic.SER.ProviderSpecialty"
+                                            displayName="Endocrinology" />
+                                    </code>
+                                    <addr use="WP">
+                                        <streetAddressLine>2001 LIND AVE</streetAddressLine>
+                                        <city>RENTON</city>
+                                        <state>WA</state>
+                                        <postalCode>98059</postalCode>
+                                    </addr>
+                                    <telecom nullFlavor="UNK" />
+                                    <assignedPerson>
+                                        <name>
+                                            <given>Ambhp1</given>
+                                            <family>Test</family>
+                                            <suffix qualifier="AC">MD</suffix>
+                                        </name>
+                                    </assignedPerson>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32" />
+                                    <id extension="501122000"
+                                        root="1.2.840.114350.1.13.297.3.7.2.686980" />
+                                    <code nullFlavor="UNK">
+                                        <originalText>Lab</originalText>
+                                    </code>
+                                    <addr use="WP">
+                                        <streetAddressLine>501 S Buena Vista St</streetAddressLine>
+                                        <county>LOS ANGELES</county>
+                                        <city>Burbank</city>
+                                        <state>CA</state>
+                                        <postalCode>91505-4809</postalCode>
+                                        <country>USA</country>
+                                    </addr>
+                                    <playingEntity classCode="PLC">
+                                        <name>PROVIDENCE ST JOSEPH MED CTR LABORATORY</name>
+                                        <desc>Lab</desc>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                        </encounter>
+                    </entry>
+                </section>
+            </component>
+        </structuredBody>
+    </component>
+</ClinicalDocument>

--- a/data/Templates/eCR/Entry/Result/_entry.liquid
+++ b/data/Templates/eCR/Entry/Result/_entry.liquid
@@ -54,7 +54,7 @@
                 {% endif -%}
             {% endif -%}
         {% endif -%}
-    {% endfor-%}   
+    {% endfor -%}   
     {% for component in comps %}
         {% include 'Entry/Result/entry_organizer_component' with component, text: text, specValue: specValue, collectTime: collectTime, receiveTime: receiveTime, diagnosticId: diagnosticId %}
     {% endfor %}

--- a/data/Templates/eCR/Entry/Result/_entry.liquid
+++ b/data/Templates/eCR/Entry/Result/_entry.liquid
@@ -16,6 +16,7 @@
         {% include 'Reference/DiagnosticReport/Performer' ID: diagnosticId, REF: fullPerformerId -%}
         {% endif -%}
     {% endif -%}
+    {% assign collectTime = null %}
     {% if entry.organizer.effectiveTime.low and entry.organizer.effectiveTime.low.value -%}
         {% assign collectTime = entry.organizer.effectiveTime.low.value -%}
     {% elsif entry.organizer.effectiveTime.high and entry.organizer.effectiveTime.high.value -%}
@@ -24,6 +25,8 @@
         {% assign collectTime = entry.organizer.effectiveTime.value -%}
     {% endif -%}
     
+    {% assign specValue = null %}
+    {% assign recieveTime = null %}
     {% assign comps = entry.organizer.component | to_array -%}
     {% for comp in comps -%}
         {% if comp.procedure  -%}
@@ -53,6 +56,6 @@
         {% endif -%}
     {% endfor-%}   
     {% for component in comps %}
-        {% include 'Entry/Result/entry_organizer_component' with component, text: text %}
+        {% include 'Entry/Result/entry_organizer_component' with component, text: text, specValue: specValue, collectTime: collectTime, receiveTime: receiveTime, diagnosticId: diagnosticId %}
     {% endfor %}
 {% endif -%}

--- a/data/Templates/eCR/Entry/Result/_entry.liquid
+++ b/data/Templates/eCR/Entry/Result/_entry.liquid
@@ -51,12 +51,15 @@
                 {% elsif playingEntity.code.displayName -%}
                      {% assign specValue = playingEntity.code.displayName -%}
                 {% else -%}
-                    {% assign specValue = "None" -%}
+                    {% comment %} {% assign specValue = "None" -%} {% endcomment %}
                 {% endif -%}
             {% else  -%}
-                {% assign specValue = "None" -%}
+                {% comment %} {% assign specValue = "None" -%} {% endcomment %}
             {% endif -%}
         {% endif -%}
+        {% if specValue == null and receiveTime != null %}
+            {{ comp.procedure | print_object }}
+        {% endif %}
     {% endfor-%}   
     {% for component in comps %}
         {% include 'Entry/Result/entry_organizer_component' with component, text: text %}

--- a/data/Templates/eCR/Entry/Result/_entry.liquid
+++ b/data/Templates/eCR/Entry/Result/_entry.liquid
@@ -22,8 +22,6 @@
         {% assign collectTime = entry.organizer.effectiveTime.high.value -%}
     {% elsif entry.organizer.effectiveTime and entry.organizer.effectiveTime.value and entry.organizer.effectiveTime.value != "UNK"-%}
         {% assign collectTime = entry.organizer.effectiveTime.value -%}
-    {% else -%}
-        {% assign collectTime = "None" -%}
     {% endif -%}
     
     {% assign comps = entry.organizer.component | to_array -%}
@@ -50,16 +48,9 @@
                     {% assign specValue = playingEntity.code.originalText._ -%}
                 {% elsif playingEntity.code.displayName -%}
                      {% assign specValue = playingEntity.code.displayName -%}
-                {% else -%}
-                    {% comment %} {% assign specValue = "None" -%} {% endcomment %}
                 {% endif -%}
-            {% else  -%}
-                {% comment %} {% assign specValue = "None" -%} {% endcomment %}
             {% endif -%}
         {% endif -%}
-        {% if specValue == null and receiveTime != null %}
-            {{ comp.procedure | print_object }}
-        {% endif %}
     {% endfor-%}   
     {% for component in comps %}
         {% include 'Entry/Result/entry_organizer_component' with component, text: text %}

--- a/data/Templates/eCR/Entry/Result/_entry.liquid
+++ b/data/Templates/eCR/Entry/Result/_entry.liquid
@@ -26,7 +26,7 @@
     {% endif -%}
     
     {% assign specValue = null %}
-    {% assign recieveTime = null %}
+    {% assign receiveTime = null %}
     {% assign comps = entry.organizer.component | to_array -%}
     {% for comp in comps -%}
         {% if comp.procedure  -%}
@@ -59,3 +59,7 @@
         {% include 'Entry/Result/entry_organizer_component' with component, text: text, specValue: specValue, collectTime: collectTime, receiveTime: receiveTime, diagnosticId: diagnosticId %}
     {% endfor %}
 {% endif -%}
+{% comment %} Prevent weird variable leakage {% endcomment %}
+{% assign specValue = null %}
+{% assign receiveTime = null %}
+{% assign collectTime = null %}

--- a/data/Templates/eCR/Resource/_Observation.liquid
+++ b/data/Templates/eCR/Resource/_Observation.liquid
@@ -140,23 +140,23 @@
         {% assign observationValueReferenceValue = observationEntry.value.reference.value -%}
         "extension":
             [ {
-                {% if specimenValue and specimenValue != "None" or collectTime and collectTime != "None" or observationTextReferenceValue != "None" or observationValueReferenceValue != "None" -%}
+                {% if specimenValue != null or collectTime != null or receiveTime != null or observationTextReferenceValue != null or observationValueReferenceValue != null -%}
 
                     "url" : "http://hl7.org/fhir/R4/specimen.html",
                     "extension": [
-                    {% if specimenValue and specimenValue != "None" -%}
+                    {% if specimenValue != null -%}
                         {
                             "url" : "specimen source",
                             "valueString" : "{{ specimenValue }}",
                         },
                     {% endif -%}
-                    {% if collectTime and collectTime != "None" -%}
+                    {% if collectTime != null -%}
                         {
                             "url" : "specimen collection time",
                             "valueDateTime" : "{{ collectTime | format_as_date_time }}",
                         },
                     {% endif -%}
-                    {% if receiveTime and receiveTime != "None" -%}
+                    {% if receiveTime != null -%}
                         {
                             "url" : "specimen receive time",
                             "valueDateTime" : "{{ receiveTime | format_as_date_time }}",

--- a/data/Templates/eCR/Resource/_Observation.liquid
+++ b/data/Templates/eCR/Resource/_Observation.liquid
@@ -140,7 +140,7 @@
         {% assign observationValueReferenceValue = observationEntry.value.reference.value -%}
         "extension":
             [ {
-                {% if specimenValue != null or collectTime != null or receiveTime != null or observationTextReferenceValue != null or observationValueReferenceValue != null -%}
+                {% if specimenValue != null or collectTime != null or receiveTime != null -%}
 
                     "url" : "http://hl7.org/fhir/R4/specimen.html",
                     "extension": [

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/BaseConvertDataFunctionalTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/BaseConvertDataFunctionalTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -213,6 +214,20 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests
             });
         }
 
+        public static IEnumerable<object[]> GetDataForEcr()
+        {
+            var data = new List<string[]>
+            {
+                new[] { @"EICR", @"eCR_full.xml", @"eCR_full-expected.json" },
+            };
+            return data.Select(item => new[]
+            {
+                item[0],
+                Path.Join(Constants.SampleDataDirectory, "eCR", item[1]),
+                Path.Join(Constants.ExpectedDataFolder, "eCR", item[0], item[2]),
+            });
+        }
+
         public static IEnumerable<object[]> GetDataForJson()
         {
             var data = new List<string[]>
@@ -332,8 +347,17 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests
             var actualObject = JObject.Parse(actualContent);
 
             // Remove DocumentReference, where date is different every time conversion is run and gzip result is OS dependent
-            expectedObject["entry"]?.Last()?.Remove();
-            actualObject["entry"]?.Last()?.Remove();
+            if (expectedObject["entry"]?.Last()["resource"]["resourceType"].ToString() == "DocumentReference")
+            {
+                expectedObject["entry"]?.Last()?.Remove();
+                actualObject["entry"]?.Last()?.Remove();
+            }
+
+            var diff = DiffHelper.FindDiff(actualObject, expectedObject);
+            if (diff.HasValues)
+            {
+                Console.WriteLine(diff);
+            }
 
             Assert.True(JToken.DeepEquals(expectedObject, actualObject));
         }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/ConvertDataTemplateDirectoryProviderFunctionalTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/ConvertDataTemplateDirectoryProviderFunctionalTests.cs
@@ -89,6 +89,16 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests
         }
 
         [Theory]
+        [MemberData(nameof(GetDataForEcr))]
+        public void GivenEcrDocument_WhenConverting_ExpectedFhirResourceShouldBeReturned(string rootTemplate, string inputFile, string expectedFile)
+        {
+            var templateDirectory = Path.Join(AppDomain.CurrentDomain.BaseDirectory, Constants.TemplateDirectory, "eCR");
+            var templateProvider = new TemplateProvider(templateDirectory, DataType.Ccda);
+
+            ConvertCCDAMessageAndValidateExpectedResponse(templateProvider, rootTemplate, inputFile, expectedFile);
+        }
+
+        [Theory]
         [MemberData(nameof(GetDataForStu3ToR4))]
         public void GivenStu3FhirData_WhenConverting_ExpectedR4FhirResourceShouldBeReturned(string rootTemplate, string inputFile, string expectedFile)
         {

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/DiffHelper.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/DiffHelper.cs
@@ -1,0 +1,63 @@
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests
+{
+    public static class DiffHelper
+    {
+        public static JObject FindDiff(this JToken Current, JToken Model)
+        {
+            var diff = new JObject();
+            if (JToken.DeepEquals(Current, Model)) return diff;
+
+            switch(Current.Type)
+            {
+                case JTokenType.Object:
+                    {
+                        var current = Current as JObject;
+                        var model = Model as JObject;
+                        var addedKeys = current.Properties().Select(c => c.Name).Except(model.Properties().Select(c => c.Name));
+                        var removedKeys = model.Properties().Select(c => c.Name).Except(current.Properties().Select(c => c.Name));
+                        var unchangedKeys = current.Properties().Where(c => JToken.DeepEquals(c.Value, Model[c.Name])).Select(c => c.Name);
+                        foreach (var k in addedKeys)
+                        {
+                            diff[k] = new JObject
+                            {
+                                ["+"] = Current[k]
+                            };
+                        }
+                        foreach (var k in removedKeys)
+                        {
+                            diff[k] = new JObject
+                            {
+                                ["-"] = Model[k]
+                            };
+                        }
+                        var potentiallyModifiedKeys = current.Properties().Select(c => c.Name).Except(addedKeys).Except(unchangedKeys);
+                        foreach (var k in potentiallyModifiedKeys)
+                        {
+                            var foundDiff = FindDiff(current[k], model[k]);
+                            if(foundDiff.HasValues) diff[k] = foundDiff;
+                        }
+                    }
+                    break;
+                case JTokenType.Array:
+                    {
+                        var current = Current as JArray;
+                        var model = Model as JArray;
+                        var plus = new JArray(current.Except(model, new JTokenEqualityComparer()));
+                        var minus = new JArray(model.Except(current, new JTokenEqualityComparer()));
+                        if (plus.HasValues) diff["+"] = plus;
+                        if (minus.HasValues) diff["-"] = minus;
+                    }
+                    break;
+                default:
+                    diff["+"] = Current;
+                    diff["-"] = Model;
+                    break;
+            }
+
+            return diff;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/DiffHelper.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/DiffHelper.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests
 {
+    // from https://stackoverflow.com/questions/24876082/find-and-return-json-differences-using-newtonsoft-in-c
     public static class DiffHelper
     {
         public static JObject FindDiff(this JToken Current, JToken Model)

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
@@ -974,7 +974,10 @@
             "city": "NEWPORT BEACH",
             "state": "CA",
             "country": "USA",
-            "postalCode": "92663"
+            "postalCode": "92663",
+            "period": {
+              "start": "2019-04-10"
+            }
           }
         ],
         "maritalStatus": {

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
@@ -1,0 +1,6024 @@
+{
+  "resourceType": "Bundle",
+  "type": "batch",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:1.2.840.114350.1.13.297.3.7.8.688883.538441",
+      "resource": {
+        "resourceType": "Composition",
+        "id": "1.2.840.114350.1.13.297.3.7.8.688883.538441",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/eicr-composition"
+          ]
+        },
+        "identifier": [
+          {
+            "use": "official",
+            "type": {
+              "coding": [
+                {
+                  "code": "55751-2",
+                  "system": "http://loinc.org",
+                  "display": "Initial Public Health Case Report"
+                }
+              ]
+            },
+            "value": "7a89f990-3f70-11ed-9549-c301d81100b2",
+            "assigner": {
+              "display": "EPC"
+            }
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/composition-clinicaldocument-versionNumber",
+            "valueString": "15"
+          },
+          {
+            "url": "https://www.hl7.org/implement/standards/product_brief.cfm?product_id=436",
+            "valueString": "2016-12-01"
+          }
+        ],
+        "status": "final",
+        "type": {
+          "coding": [
+            {
+              "code": "55751-2",
+              "system": "http://loinc.org",
+              "display": "Initial Public Health Case Report"
+            }
+          ]
+        },
+        "date": "2022-09-28T14:01:01-07:00",
+        "title": "Initial Public Health Case Report",
+        "confidentiality": "N",
+        "section": [
+          {
+            "id": "59ecd3e2-c425-9925-b7ad-7440009463e5",
+            "title": "Miscellaneous Notes",
+            "text": {
+              "status": "generated",
+              "div": "<content ID=\"nof2\" xmlns=\"urn:hl7-org:v3\">Not on file</content><footnote ID=\"subTitle1\" styleCode=\"xSectionSubTitle\" xmlns=\"urn:hl7-org:v3\">documented in this encounter</footnote>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "10164-2",
+                  "system": "http://loinc.org",
+                  "display": "HISTORY OF PRESENT ILLNESS"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "A84C7F7E-3F70-11ED-9549-C301D81100B2",
+            "title": "Immunizations",
+            "text": {
+              "status": "generated",
+              "div": "<table xmlns=\"urn:hl7-org:v3\"><colgroup><col width=\"25%\" /><col width=\"50%\" /><col width=\"25%\" /></colgroup><thead><tr><th>Name</th><th>Administration Dates</th><th>Next Due</th></tr></thead><tbody><tr ID=\"immunization4\"><td ID=\"immunization4Name\">DTAP-HIB-IPV (PENTACEL)</td><td><content>04/16/2010</content></td><td /></tr><tr ID=\"immunization6\"><td ID=\"immunization6Name\">HEP A (ADULT) 2 DOSE</td><td><content>11/11/2011</content></td><td /></tr><tr ID=\"immunization8\"><td ID=\"immunization8Name\">HEP B (PED,ADOLESCENT) 3 DOSE</td><td><content>03/21/1974</content></td><td /></tr><tr ID=\"immunization7\"><td ID=\"immunization7Name\">MENINGOCOCCAL CONJUGATE,MENACTRA (PED/ADOL/ADULT)</td><td><content>11/16/2020</content></td><td /></tr><tr ID=\"immunization5\"><td ID=\"immunization5Name\">TDAP, (ADOL/ADULT)</td><td><content>11/10/2020</content></td><td /></tr></tbody></table><footnote ID=\"subTitle3\" styleCode=\"xSectionSubTitle\" xmlns=\"urn:hl7-org:v3\">documented as of this encounter</footnote>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "11369-6",
+                  "system": "http://loinc.org",
+                  "display": "History of Immunization Narrative"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "A853DBC0-3F70-11ED-9549-C301D81100B2",
+            "title": "Administered Medications",
+            "text": {
+              "status": "generated",
+              "div": "<content ID=\"nof10\" xmlns=\"urn:hl7-org:v3\">Not on file</content><footnote ID=\"subTitle9\" styleCode=\"xSectionSubTitle\" xmlns=\"urn:hl7-org:v3\">documented in this encounter</footnote>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "29549-3",
+                  "system": "http://loinc.org",
+                  "display": "MEDICATIONS ADMINISTERED"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "2a6a9ce3-c605-ff37-1f76-86650fe02739",
+            "title": "Plan of Treatment",
+            "text": {
+              "status": "generated",
+              "div": "<paragraph xmlns=\"urn:hl7-org:v3\">Not on file</paragraph><footnote ID=\"subTitle11\" styleCode=\"xSectionSubTitle\" xmlns=\"urn:hl7-org:v3\">documented as of this encounter</footnote>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "18776-5",
+                  "system": "http://loinc.org",
+                  "display": "Plan of care note"
+                }
+              ]
+            },
+            "mode": "snapshot",
+            "entry": [
+              {
+                "reference": "CarePlan/42008b73-bc71-2c3e-1078-9799e5db7fe1"
+              }
+            ]
+          },
+          {
+            "id": "A8648114-3F70-11ED-9549-C301D81100B2",
+            "title": "Problems",
+            "text": {
+              "status": "generated",
+              "div": "<table xmlns=\"urn:hl7-org:v3\"><colgroup><col width=\"75%\" /><col width=\"25%\" /></colgroup><thead><tr><th>Active Problems</th><th>Noted Date</th></tr></thead><tbody><tr ID=\"problem20\" styleCode=\"xRowNormal\"><td ID=\"problem20name\">Bipolar I disorder</td><td>11/19/20</td></tr><tr ID=\"problem21\" styleCode=\"xRowAlt\"><td ID=\"problem21name\">Reactive depression</td><td>11/19/20</td></tr><tr ID=\"problem18\" styleCode=\"xRowNormal\"><td ID=\"problem18name\">Rheumatoid arthritis with negative rheumatoid factor</td><td>11/16/20</td></tr><tr ID=\"problem19\" styleCode=\"xRowAlt\"><td ID=\"problem19name\">Arthralgia of both ankles</td><td>11/16/20</td></tr><tr ID=\"problem16\" styleCode=\"xRowNormal\"><td ID=\"problem16name\">Anxiety</td><td>11/10/20</td></tr><tr ID=\"problem17\" styleCode=\"xRowAlt\"><td ID=\"problem17name\">Asthma</td><td>11/10/20</td></tr><tr ID=\"problem15\" styleCode=\"xRowNormal\"><td ID=\"problem15name\">Knee pain</td><td>4/29/19</td></tr><tr ID=\"problem14\" styleCode=\"xRowAlt\"><td ID=\"problem14name\">Sprain of calcaneofibular ligament of right ankle</td><td>4/16/19</td></tr><tr styleCode=\"xRowAlt xMergeUp\"><td ID=\"problem14comment\" colspan=\"2\" styleCode=\"xallIndent\"><content>A note:</content><paragraph styleCode=\"xcellHeader\">Last Assessment &amp; Plan: </paragraph><content><content styleCode=\"xLabel\">Formatting of this note might be different from the original.</content><br />This is my note about this problem.</content><br /></td></tr></tbody></table><footnote ID=\"subTitle13\" styleCode=\"xSectionSubTitle\" xmlns=\"urn:hl7-org:v3\">documented as of this encounter (statuses as of 09/28/2022)</footnote>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "11450-4",
+                  "system": "http://loinc.org",
+                  "display": "Problem list - Reported"
+                }
+              ]
+            },
+            "mode": "snapshot",
+            "entry": [
+              {
+                "display": "Problem - Sprain of calcaneofibular ligament of right ankle",
+                "reference": "Condition/34728086-4b53-a5f0-8eaa-61f72b79a78c"
+              },
+              {
+                "display": "Problem - Knee pain",
+                "reference": "Condition/b3f9a35e-828c-e0aa-f083-b95837e69a31"
+              },
+              {
+                "display": "Problem - Anxiety",
+                "reference": "Condition/9e83e83e-8c39-c58f-d96c-72bb94b75531"
+              },
+              {
+                "display": "Problem - Asthma",
+                "reference": "Condition/b8166f2c-ad38-da4b-aec4-974cc2c6664f"
+              },
+              {
+                "display": "Problem - Rheumatoid arthritis with negative rheumatoid factor",
+                "reference": "Condition/5dad7636-f4ae-0823-a58d-3536ce82c42b"
+              },
+              {
+                "display": "Problem - Arthralgia of both ankles",
+                "reference": "Condition/f5840e99-3485-96c0-ee31-139f1cdb7c36"
+              },
+              {
+                "display": "Problem - Bipolar I disorder",
+                "reference": "Condition/650e3ee3-148d-3895-2406-7dc0da609ae0"
+              },
+              {
+                "display": "Problem - Reactive depression",
+                "reference": "Condition/e6367140-81af-9ccf-c974-c2170bc95500"
+              }
+            ]
+          },
+          {
+            "id": "bbec169d-3c40-32f9-03df-b5594fe80c34",
+            "title": "Reason for Visit",
+            "text": {
+              "status": "generated",
+              "div": "<content ID=\"nof22\" xmlns=\"urn:hl7-org:v3\">Not on file</content>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "29299-5",
+                  "system": "http://loinc.org",
+                  "display": "REASON FOR VISIT"
+                }
+              ]
+            },
+            "mode": "snapshot",
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/cda/ccda/StructureDefinition/2.16.840.1.113883.10.20.22.2.12",
+                "valueString": "Not on file"
+              }
+            ]
+          },
+          {
+            "id": "A87B29AA-3F70-11ED-9549-C301D81100B2",
+            "title": "Results",
+            "text": {
+              "status": "generated",
+              "div": "<list styleCode=\"xTOC\" xmlns=\"urn:hl7-org:v3\"><item ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845\"><caption ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Procedure\">Stool Pathogens, NAAT, 12 to 25 Targets (09/28/2022 1:51 PM PDT)</caption><table><colgroup><col width=\"20%\" /><col width=\"12%\" /><col width=\"8%\" /><col width=\"20%\" /><col span=\"2\" width=\"10%\" /><col width=\"20%\" /></colgroup><thead><tr><th>Component</th><th>Value</th><th>Ref Range</th><th>Test Method</th><th>Analysis Time</th><th>Performed At</th><th>Pathologist Signature</th></tr></thead><tbody><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp1\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp1Name\">Campylobacter, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp1TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp1Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp2\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp2Name\">Plesiomonas shigelloides, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp2TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp2Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp3\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp3Name\">Salmonella, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp3TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp3Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp4\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp4Name\">Vibrio, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp4TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp4Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp5\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp5Name\">Vibrio cholerae, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp5TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp5Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp6\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp6Name\">Yersinia enterocolitica, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp6TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp6Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp7\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp7Name\">E. Coli (EAEC), NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp7TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp7Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp8\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp8Name\">E. Coli (EPEC), NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp8TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp8Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp9\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp9Name\">E. Coli (ETEC), NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp9TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp9Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp10\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp10Name\">Shiga-Like Toxin E. Coli (STEC), NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp10TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp10Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp11\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp11Name\">Shigella/EIEC, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp11TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp11Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp12\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp12Name\">Cryptosporidium, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp12TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp12Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp13\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp13Name\">Cyclospora cayetanensis, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp13TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp13Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp14\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp14Name\">E. histolytica, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp14TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp14Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp15\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp15Name\">Giardia lamblia, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp15TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp15Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp16\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp16Name\">Adenovirus F 40/41, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp16TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp16Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp17\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp17Name\">Astrovirus, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp17TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp17Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp18\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp18Name\">Norovirus, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp18TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp18Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp19\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp19Name\">Rotavirus A, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp19TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp19Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp20\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp20Name\">Sapovirus, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp20TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 1:59 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp20Signature\" /></tr></tbody></table><table><colgroup><col span=\"5\" width=\"20%\" /></colgroup><thead><tr><th>Specimen (Source)</th><th>Anatomical Location / Laterality</th><th>Collection Method / Volume</th><th>Collection Time</th><th>Received Time</th></tr></thead><tbody><tr styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Specimen\"> Stool</td><td>STOOL SPECIMEN / Unknown</td><td /><td>09/28/2022 1:51 PM PDT</td><td>09/28/2022 1:51 PM PDT</td></tr></tbody></table><table><colgroup><col width=\"20%\" /><col width=\"80%\" /></colgroup><thead><tr><th>Authorizing Provider</th><th>Result Type</th></tr></thead><tbody><tr><td>Ambhp1 Test MD</td><td>MICROBIOLOGY - GENERAL ORDERABLES</td></tr></tbody></table><table><colgroup><col span=\"3\" width=\"20%\" /><col width=\"40%\" /></colgroup><thead><tr><th>Performing Organization</th><th>Address</th><th>City/State/ZIP Code</th><th>Phone Number</th></tr></thead><tbody><tr><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.PerformingLab\"><paragraph>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</paragraph></td><td><paragraph>501 S. Buena Vista Street</paragraph></td><td><paragraph>Burbank, CA 91505</paragraph></td><td><paragraph>818-847-6000</paragraph></td></tr></tbody></table></item><item ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844\"><caption ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Procedure\" styleCode=\"xAbnormal\">(ABNORMAL) Stool Pathogens, NAAT, 12 to 25 Targets (09/28/2022 1:51 PM PDT)</caption><table><colgroup><col width=\"20%\" /><col width=\"12%\" /><col width=\"8%\" /><col width=\"20%\" /><col span=\"2\" width=\"10%\" /><col width=\"20%\" /></colgroup><thead><tr><th>Component</th><th>Value</th><th>Ref Range</th><th>Test Method</th><th>Analysis Time</th><th>Performed At</th><th>Pathologist Signature</th></tr></thead><tbody><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp1\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp1Name\">Campylobacter, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp1TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp1Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp2\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp2Name\">Plesiomonas shigelloides, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp2TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp2Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp3\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp3Name\">Salmonella, NAAT</td><td><content styleCode=\"xflagData\">DETECTED</content><content styleCode=\"xflagData\"> (AA)</content></td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp3TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp3Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp4\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp4Name\">Vibrio, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp4TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp4Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp5\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp5Name\">Vibrio cholerae, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp5TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp5Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp6\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp6Name\">Yersinia enterocolitica, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp6TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp6Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp7\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp7Name\">E. Coli O157, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp7TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp7Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp8\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp8Name\">E. Coli (EAEC), NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp8TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp8Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp9\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp9Name\">E. Coli (EPEC), NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp9TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp9Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp10\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp10Name\">E. Coli (ETEC), NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp10TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp10Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp11\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp11Name\">Shiga-Like Toxin E. Coli (STEC), NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp11TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp11Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp12\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp12Name\">Shigella/EIEC, NAAT</td><td><content styleCode=\"xflagData\">DETECTED</content><content styleCode=\"xflagData\"> (AA)</content></td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp12TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp12Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp13\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp13Name\">Cryptosporidium, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp13TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp13Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp14\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp14Name\">Cyclospora cayetanensis, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp14TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp14Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp15\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp15Name\">E. histolytica, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp15TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp15Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp16\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp16Name\">Giardia lamblia, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp16TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp16Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp17\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp17Name\">Adenovirus F 40/41, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp17TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp17Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp18\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp18Name\">Astrovirus, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp18TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp18Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp19\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp19Name\">Norovirus, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp19TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp19Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp20\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp20Name\">Rotavirus A, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp20TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp20Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp21\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp21Name\">Sapovirus, NAAT</td><td>Not Detected</td><td>Not Detected</td><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp21TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp21Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp22\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp22Name\">GI Pathogens Panel</td><td>Acceptable</td><td /><td><paragraph ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp22TestMethodName1\">LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM</paragraph></td><td>09/28/2022 2:00 PM PDT</td><td>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</td><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp22Signature\" /></tr></tbody></table><table><colgroup><col span=\"5\" width=\"20%\" /></colgroup><thead><tr><th>Specimen (Source)</th><th>Anatomical Location / Laterality</th><th>Collection Method / Volume</th><th>Collection Time</th><th>Received Time</th></tr></thead><tbody><tr styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Specimen\"> Stool</td><td>STOOL SPECIMEN / Unknown</td><td /><td>09/28/2022 1:51 PM PDT</td><td>09/28/2022 1:51 PM PDT</td></tr></tbody></table><table><colgroup><col width=\"20%\" /><col width=\"80%\" /></colgroup><thead><tr><th>Authorizing Provider</th><th>Result Type</th></tr></thead><tbody><tr><td>Ambhp1 Test MD</td><td>MICROBIOLOGY - GENERAL ORDERABLES</td></tr></tbody></table><table><colgroup><col span=\"3\" width=\"20%\" /><col width=\"40%\" /></colgroup><thead><tr><th>Performing Organization</th><th>Address</th><th>City/State/ZIP Code</th><th>Phone Number</th></tr></thead><tbody><tr><td ID=\"Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.PerformingLab\"><paragraph>PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA 05D0672675)</paragraph></td><td><paragraph>501 S. Buena Vista Street</paragraph></td><td><paragraph>Burbank, CA 91505</paragraph></td><td><paragraph>818-847-6000</paragraph></td></tr></tbody></table></item></list><footnote ID=\"subTitle23\" styleCode=\"xSectionSubTitle\" xmlns=\"urn:hl7-org:v3\">documented in this encounter</footnote>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "30954-2",
+                  "system": "http://loinc.org",
+                  "display": "Relevant diagnostic tests/laboratory data Narrative"
+                }
+              ]
+            },
+            "mode": "snapshot",
+            "entry": [
+              {
+                "reference": "Observation/a00006e4-f2d8-0c10-b96b-6b56def874e1",
+                "display": "Campylobacter, NAAT"
+              },
+              {
+                "reference": "Observation/386f91f9-9bb9-44f2-4e99-284e3d0051c8",
+                "display": "Plesiomonas shigelloides, NAAT"
+              },
+              {
+                "reference": "Observation/db2ddcd3-de40-a980-701d-3295256719bb",
+                "display": "Salmonella, NAAT"
+              },
+              {
+                "reference": "Observation/ef277bb4-7302-f66e-0585-a90c6fe7b63f",
+                "display": "Vibrio, NAAT"
+              },
+              {
+                "reference": "Observation/28949844-281e-0581-70e8-38ecd287116b",
+                "display": "Vibrio cholerae, NAAT"
+              },
+              {
+                "reference": "Observation/38af00cb-3319-514b-3a9c-b6f71d57a6a4",
+                "display": "Yersinia enterocolitica, NAAT"
+              },
+              {
+                "reference": "Observation/9256f7d3-98ec-fce8-90d1-57aec284c887",
+                "display": "E. Coli O157, NAAT"
+              },
+              {
+                "reference": "Observation/9f4402c6-0783-bc2d-926f-3c7b96146cfd",
+                "display": "E. Coli (EAEC), NAAT"
+              },
+              {
+                "reference": "Observation/06e693a9-b5c4-51ac-8888-086131261c46",
+                "display": "E. Coli (EPEC), NAAT"
+              },
+              {
+                "reference": "Observation/b33d223c-9947-0795-a25d-bc0510716509",
+                "display": "E. Coli (ETEC), NAAT"
+              },
+              {
+                "reference": "Observation/7086a08a-8e86-6354-8c0c-88d42a1c5234",
+                "display": "Shiga-Like Toxin E. Coli (STEC), NAAT"
+              },
+              {
+                "reference": "Observation/d41aae21-a91a-74d8-3423-260256bc48b5",
+                "display": "Shigella/EIEC, NAAT"
+              },
+              {
+                "reference": "Observation/93caad24-d8f1-6b8d-82f7-7e757c5f145b",
+                "display": "Cryptosporidium, NAAT"
+              },
+              {
+                "reference": "Observation/63537cc7-04fe-9788-5390-25547813e41d",
+                "display": "Cyclospora cayetanensis, NAAT"
+              },
+              {
+                "reference": "Observation/23ce6d59-e5cb-a803-97d0-28e9c9ea9cf5",
+                "display": "E. histolytica, NAAT"
+              },
+              {
+                "reference": "Observation/1bace839-10e5-14ad-eb5d-1017c1b563ed",
+                "display": "Giardia lamblia, NAAT"
+              },
+              {
+                "reference": "Observation/0b6a2f7f-6ee8-c00d-8519-70ae47a94d01",
+                "display": "Adenovirus F 40/41, NAAT"
+              },
+              {
+                "reference": "Observation/993fdfcb-0d15-1ce5-7652-d9cbccd77d7f",
+                "display": "Astrovirus, NAAT"
+              },
+              {
+                "reference": "Observation/b8746e9c-ed12-1069-1168-095692b463fb",
+                "display": "Norovirus, NAAT"
+              },
+              {
+                "reference": "Observation/a04992b6-9980-8866-55b9-1187c93c378c",
+                "display": "Rotavirus A, NAAT"
+              },
+              {
+                "reference": "Observation/9b963591-7fdd-96a5-69ec-1d56d9dec3a3",
+                "display": "Sapovirus, NAAT"
+              },
+              {
+                "reference": "Observation/3d694e5a-92cc-9af5-4365-cfede30abe3c",
+                "display": "Lab Interpretation"
+              },
+              {
+                "reference": "Observation/57c969ce-4656-9526-8d27-e39eb8e33625",
+                "display": "Campylobacter, NAAT"
+              },
+              {
+                "reference": "Observation/af92101a-6b5d-50b3-ebdb-45658ec25808",
+                "display": "Plesiomonas shigelloides, NAAT"
+              },
+              {
+                "reference": "Observation/c0b99528-7b83-6cdb-b4af-4376e969e11d",
+                "display": "Salmonella, NAAT"
+              },
+              {
+                "reference": "Observation/a13fc3f5-06ed-2105-98c7-e2e0094fa1f6",
+                "display": "Vibrio, NAAT"
+              },
+              {
+                "reference": "Observation/f74c4591-b7a0-eceb-f8be-f1441c4bb5f1",
+                "display": "Vibrio cholerae, NAAT"
+              },
+              {
+                "reference": "Observation/87f76719-5e72-e3cd-cf52-5fc8635eebbd",
+                "display": "Yersinia enterocolitica, NAAT"
+              },
+              {
+                "reference": "Observation/84ba7cd9-c570-9a62-7b1f-d08b19af0973",
+                "display": "E. Coli (EAEC), NAAT"
+              },
+              {
+                "reference": "Observation/ee4f7291-130b-ae27-8b59-60b93c8c6e1b",
+                "display": "E. Coli (EPEC), NAAT"
+              },
+              {
+                "reference": "Observation/3351c512-bc9e-0bda-3b51-6c6f807b772d",
+                "display": "E. Coli (ETEC), NAAT"
+              },
+              {
+                "reference": "Observation/4d20693f-fe7d-5c98-e585-a89ac8088a59",
+                "display": "Shiga-Like Toxin E. Coli (STEC), NAAT"
+              },
+              {
+                "reference": "Observation/0f447d83-8760-299e-8faa-7343d4988b94",
+                "display": "Shigella/EIEC, NAAT"
+              },
+              {
+                "reference": "Observation/08f51019-a406-1eed-170c-297fa8cd0b68",
+                "display": "Cryptosporidium, NAAT"
+              },
+              {
+                "reference": "Observation/4621b183-3bc3-6865-6f28-b0561a641270",
+                "display": "Cyclospora cayetanensis, NAAT"
+              },
+              {
+                "reference": "Observation/64b0843f-a299-d049-2d18-29cd8b6de36b",
+                "display": "E. histolytica, NAAT"
+              },
+              {
+                "reference": "Observation/c15f50f5-6285-6956-743e-4cbf10f77604",
+                "display": "Giardia lamblia, NAAT"
+              },
+              {
+                "reference": "Observation/817b3760-b4a9-9265-e798-d0b2efc7150b",
+                "display": "Adenovirus F 40/41, NAAT"
+              },
+              {
+                "reference": "Observation/51864ad2-6ad4-3b11-eba3-a4ced945877c",
+                "display": "Astrovirus, NAAT"
+              },
+              {
+                "reference": "Observation/17d1cfd4-d525-16cf-5021-b918be56fe8f",
+                "display": "Norovirus, NAAT"
+              },
+              {
+                "reference": "Observation/e6b1b714-4a40-5c91-8641-7e324b913652",
+                "display": "Rotavirus A, NAAT"
+              },
+              {
+                "reference": "Observation/bb8b7102-09f9-7d34-fa63-70c01d276895",
+                "display": "Sapovirus, NAAT"
+              },
+              {
+                "reference": "Observation/a3d6cd6c-ef20-8b18-9c50-d62212af9cf0",
+                "display": "Lab Interpretation"
+              }
+            ]
+          },
+          {
+            "id": "a14a8776-dd93-06b9-6c14-705733b99d32",
+            "title": "Social History",
+            "text": {
+              "status": "generated",
+              "div": "<table ID=\"sochist25\" xmlns=\"urn:hl7-org:v3\"><colgroup><col span=\"2\" width=\"25%\" /><col width=\"13%\" /><col width=\"12%\" /><col width=\"25%\" /></colgroup><thead><tr><th>Tobacco Use</th><th>Types</th><th>Packs/Day</th><th>Years Used</th><th>Date</th></tr></thead><tbody><tr><td>Smoking Tobacco: Never</td><td /><td ID=\"sochist25packsperday\" /><td /><td /></tr><tr ID=\"sochist25smokeless\" styleCode=\"xRowAlt\"><td>Smokeless Tobacco: Never</td><td /><td /><td /><td /></tr></tbody></table><table xmlns=\"urn:hl7-org:v3\"><colgroup><col span=\"2\" width=\"25%\" /><col width=\"50%\" /></colgroup><thead><tr><th>Alcohol Use</th><th>Standard Drinks/Week</th><th>Comments</th></tr></thead><tbody><tr><td ID=\"alcoholStatus\">Yes</td><td>0 (1 standard drink = 0.6 oz pure alcohol)</td><td /></tr></tbody></table><table xmlns=\"urn:hl7-org:v3\"><colgroup><col width=\"25%\" /><col width=\"75%\" /></colgroup><thead><tr><th>Sex Assigned at Birth</th><th>Date Recorded</th></tr></thead><tbody><tr ID=\"BirthSex26\"><td ID=\"BirthSex26Value\">Not on file</td><td /></tr></tbody></table><footnote ID=\"subTitle24\" styleCode=\"xSectionSubTitle\" xmlns=\"urn:hl7-org:v3\">documented as of this encounter</footnote>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "29762-2",
+                  "system": "http://loinc.org",
+                  "display": "Social history Narrative"
+                }
+              ]
+            },
+            "mode": "snapshot",
+            "entry": [
+              {
+                "reference": "Observation/8216269f-2076-4765-26e8-f9760da7da3c"
+              },
+              {
+                "reference": "Observation/70f271bc-1399-6de9-83b6-dd02ae368a16"
+              },
+              {
+                "reference": "Observation/8bf22e17-362c-0c96-6cd2-8d22655b24bd"
+              }
+            ]
+          },
+          {
+            "id": "3f36d609-b243-e662-2369-b6a66d256c9a",
+            "title": "Encounter Details",
+            "text": {
+              "status": "generated",
+              "div": "<table xmlns=\"urn:hl7-org:v3\"><colgroup><col width=\"10%\" /><col width=\"15%\" /><col span=\"3\" width=\"25%\" /></colgroup><thead><tr><th>Date</th><th>Type</th><th>Department</th><th>Care Team</th><th>Description</th></tr></thead><tbody><tr ID=\"encounter27\" styleCode=\"xRowNormal\"><td>9/28/22</td><td ID=\"encounter27type\">Lab Requisition</td><td><paragraph>PROVIDENCE ST JOSEPH MED CTR LABORATORY</paragraph><paragraph>501 S Buena Vista St</paragraph><paragraph>Burbank, CA 91505-4809</paragraph><paragraph>818-847-6060</paragraph></td><td><paragraph styleCode=\"Bold\">Test, Ambhp1, MD</paragraph><paragraph>2001 LIND AVE</paragraph><paragraph>RENTON, WA 98059</paragraph></td><td /></tr></tbody></table>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "46240-8",
+                  "system": "http://loinc.org",
+                  "display": "History of Hospitalizations+Outpatient visits Narrative"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "relatesTo": [
+          {
+            "code": "replaces",
+            "targetReference": {
+              "reference": "Composition/1.2.840.114350.1.13.297.3.7.8.688883.538440"
+            },
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/composition-clinicaldocument-versionNumber",
+                "valueString": "14"
+              }
+            ]
+          }
+        ],
+        "encounter": {
+          "reference": "Encounter/ec64cd62-282b-9c29-bdd3-f59d3aa15b3a"
+        },
+        "custodian": {
+          "reference": "Organization/401e4e5a-69e1-bdf6-7016-6aa11dfdd01f"
+        },
+        "author": [
+          {
+            "reference": "PractitionerRole/3beafd46-87f4-ba10-219f-09ddfbbcc741"
+          },
+          {
+            "reference": "Device/af3dff8a-77cc-434e-4618-0f249cf770a0"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Composition/1.2.840.114350.1.13.297.3.7.8.688883.538441"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:ec64cd62-282b-9c29-bdd3-f59d3aa15b3a",
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "ec64cd62-282b-9c29-bdd3-f59d3aa15b3a",
+        "status": "unknown",
+        "class": {
+          "code": "AMB",
+          "system": "urn:oid:2.16.840.1.113883.5.4",
+          "display": "Ambulatory"
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.3.698084.8",
+            "value": "50000595021"
+          }
+        ],
+        "period": {
+          "start": "2022-09-28",
+          "end": "2022-09-28"
+        },
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "location": [
+          {
+            "id": "1.2.840.114350.1.13.297.3.7.2.686980",
+            "location": {
+              "reference": "Location/64cbd9e3-1a67-d754-a098-211ca812a775",
+              "display": "PROVIDENCE ST JOSEPH MED CTR LABORATORY"
+            },
+            "extension": [
+              {
+                "url": "http://build.fhir.org/ig/HL7/case-reporting/StructureDefinition-us-ph-location-definitions.html#Location.type",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "code": "257622000",
+                      "system": "http://snomed.info/sct",
+                      "display": "Healthcare Facility"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "serviceProvider": {
+          "reference": "Organization/61e27f76-b2a4-886d-0f3a-11de98b0085d"
+        },
+        "participant": [
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code": "ATND"
+                  }
+                ]
+              }
+            ],
+            "individual": {
+              "reference": "PractitionerRole/9dde2db0-9832-9fe7-54c0-bd1b4a696c5b"
+            }
+          },
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code": "ATND"
+                  }
+                ]
+              }
+            ],
+            "period": {
+              "start": "2022-09-28"
+            },
+            "individual": {
+              "reference": "PractitionerRole/7ff14ada-9553-34b4-dde7-c03598261336"
+            }
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Encounter/ec64cd62-282b-9c29-bdd3-f59d3aa15b3a"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:64cbd9e3-1a67-d754-a098-211ca812a775",
+      "resource": {
+        "resourceType": "Location",
+        "id": "64cbd9e3-1a67-d754-a098-211ca812a775",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.686980",
+            "value": "501122000"
+          }
+        ],
+        "name": "PROVIDENCE ST JOSEPH MED CTR LABORATORY",
+        "address": {
+          "use": "work",
+          "line": [
+            "501 S Buena Vista St"
+          ],
+          "city": "Burbank",
+          "state": "CA",
+          "country": "USA",
+          "postalCode": "91505-4809",
+          "district": "LOS ANGELES"
+        },
+        "type": [
+          {
+            "coding": [
+              {
+                "code": "257622000",
+                "system": "http://snomed.info/sct",
+                "display": "Healthcare Facility"
+              }
+            ]
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Location/64cbd9e3-1a67-d754-a098-211ca812a775"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:61e27f76-b2a4-886d-0f3a-11de98b0085d",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "61e27f76-b2a4-886d-0f3a-11de98b0085d",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.696570",
+            "value": "501121"
+          }
+        ],
+        "name": "Providence St Joseph Medical Center",
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "501 S Buena Vista St"
+            ],
+            "city": "Burbank",
+            "state": "CA",
+            "country": "USA",
+            "postalCode": "91505-4809",
+            "district": "LOS ANGELES"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/61e27f76-b2a4-886d-0f3a-11de98b0085d"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:1dde1de0-65fa-bed4-6e56-e6bf9a47315a",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "1dde1de0-65fa-bed4-6e56-e6bf9a47315a",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/_datatype",
+            "valueString": "Responsible Party"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Practitioner/1dde1de0-65fa-bed4-6e56-e6bf9a47315a"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "id": "9dde2db0-9832-9fe7-54c0-bd1b4a696c5b",
+        "practitioner": {
+          "reference": "Practitioner/1dde1de0-65fa-bed4-6e56-e6bf9a47315a"
+        },
+        "organization": {
+          "reference": "Organization/1dde1de0-65fa-bed4-6e56-e6bf9a47315a"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:1dde1de0-65fa-bed4-6e56-e6bf9a47315a",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "1dde1de0-65fa-bed4-6e56-e6bf9a47315a",
+        "name": "Providence California",
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "4733 TORRANCE BLVD #4400"
+            ],
+            "city": "TORRANCE",
+            "state": "CA",
+            "country": "USA",
+            "postalCode": "90503",
+            "district": "LOS ANGELES"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/1dde1de0-65fa-bed4-6e56-e6bf9a47315a"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:1c57ea76-bd59-1913-31c0-5bb8a03631c7",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "1c57ea76-bd59-1913-31c0-5bb8a03631c7",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+          ]
+        },
+        "name": [
+          {
+            "use": "official",
+            "family": "Test",
+            "given": [
+              "Ambhp1"
+            ],
+            "suffix": [
+              " MD"
+            ]
+          }
+        ],
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "2001 LIND AVE"
+            ],
+            "city": "RENTON",
+            "state": "WA",
+            "postalCode": "98059"
+          }
+        ],
+        "qualification": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "display": "Endocrinology"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Practitioner/1c57ea76-bd59-1913-31c0-5bb8a03631c7"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "id": "7ff14ada-9553-34b4-dde7-c03598261336",
+        "practitioner": {
+          "reference": "Practitioner/1c57ea76-bd59-1913-31c0-5bb8a03631c7"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:401e4e5a-69e1-bdf6-7016-6aa11dfdd01f",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "401e4e5a-69e1-bdf6-7016-6aa11dfdd01f",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.696570",
+            "value": "50"
+          }
+        ],
+        "name": "Providence California",
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "4733 TORRANCE BLVD #4400"
+            ],
+            "city": "TORRANCE",
+            "state": "CA",
+            "country": "USA",
+            "postalCode": "90503",
+            "district": "LOS ANGELES"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+1-855-415-6179",
+            "use": "work"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/401e4e5a-69e1-bdf6-7016-6aa11dfdd01f"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:80746d38-56d1-93cd-febe-13ad0807a14b",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "80746d38-56d1-93cd-febe-13ad0807a14b",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.697780",
+            "value": "LABBACKGROUND"
+          }
+        ],
+        "name": [
+          {
+            "family": "Lab",
+            "given": [
+              "Background"
+            ]
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Practitioner/80746d38-56d1-93cd-febe-13ad0807a14b"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "id": "3beafd46-87f4-ba10-219f-09ddfbbcc741",
+        "organization": {
+          "reference": "Organization/401e4e5a-69e1-bdf6-7016-6aa11dfdd01f"
+        },
+        "practitioner": {
+          "reference": "Practitioner/80746d38-56d1-93cd-febe-13ad0807a14b"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:af3dff8a-77cc-434e-4618-0f249cf770a0",
+      "resource": {
+        "resourceType": "Device",
+        "id": "af3dff8a-77cc-434e-4618-0f249cf770a0",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.1",
+            "value": "10.1"
+          }
+        ],
+        "manufacturer": "Epic - Version 10.1",
+        "version": [
+          {
+            "value": "Epic - Version 10.1"
+          }
+        ],
+        "property": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/device-category",
+                  "code": "software",
+                  "display": "software"
+                }
+              ]
+            }
+          }
+        ],
+        "owner": {
+          "reference": "Organization/401e4e5a-69e1-bdf6-7016-6aa11dfdd01f"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Device/af3dff8a-77cc-434e-4618-0f249cf770a0"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:8766f0ee-be25-6c76-9a5d-e3885ffb79c1",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "8766f0ee-be25-6c76-9a5d-e3885ffb79c1",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.3.688884.100",
+            "value": "POC7649102"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "Test",
+            "given": [
+              "Adam"
+            ]
+          }
+        ],
+        "birthDate": "1970-01-01",
+        "deceasedBoolean": false,
+        "gender": "male",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+            "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "code": "2106-3",
+                  "display": "White"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "White"
+              }
+            ]
+          },
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+            "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "code": "2186-5",
+                  "display": "Not Hispanic or Latino"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "Not Hispanic or Latino"
+              }
+            ]
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/patient-religion",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "code": "Baptist",
+                  "system": "urn:oid:2.16.840.1.113883.5.1076"
+                }
+              ]
+            }
+          },
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+            "extension": [
+              {
+                "url": "value",
+                "valueString": "Not on file"
+              }
+            ]
+          }
+        ],
+        "address": [
+          {
+            "use": "home",
+            "line": [
+              "9 Post Lane"
+            ],
+            "city": "NEWPORT BEACH",
+            "state": "CA",
+            "country": "USA",
+            "postalCode": "92663"
+          }
+        ],
+        "maritalStatus": {
+          "coding": [
+            {
+              "code": "M",
+              "system": "urn:oid:2.16.840.1.113883.5.2",
+              "display": "Married"
+            }
+          ]
+        },
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+1-949-264-1098",
+            "use": "home"
+          },
+          {
+            "system": "email",
+            "value": "mary.gibbs@Providence.org"
+          }
+        ],
+        "contact": [
+          {
+            "relationship": [
+              {
+                "coding": [
+                  {
+                    "display": "Father"
+                  }
+                ]
+              }
+            ],
+            "telecom": [
+              {
+                "system": "phone",
+                "value": "+1-777-666-5656",
+                "use": "home"
+              }
+            ]
+          }
+        ],
+        "communication": [
+          {
+            "language": {
+              "coding": [
+                {
+                  "system": "urn:ietf:bcp:47"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:",
+      "resource": {
+        "resourceType": "CareTeam",
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:42008b73-bc71-2c3e-1078-9799e5db7fe1",
+      "resource": {
+        "resourceType": "CarePlan",
+        "id": "42008b73-bc71-2c3e-1078-9799e5db7fe1",
+        "status": "unknown",
+        "intent": "proposal",
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "CarePlan/42008b73-bc71-2c3e-1078-9799e5db7fe1"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:34728086-4b53-a5f0-8eaa-61f72b79a78c",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "34728086-4b53-a5f0-8eaa-61f72b79a78c",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.768076",
+            "value": "35372"
+          }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "code": "55561003",
+              "system": "http://snomed.info/sct",
+              "display": "Active"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "code": "problem-item-list",
+                "display": "Problem List Item",
+                "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "code": "11833511000119101",
+              "system": "http://snomed.info/sct"
+            },
+            {
+              "code": "S93.411A",
+              "system": "urn:oid:2.16.840.1.113883.6.90",
+              "display": "Sprain of calcaneofibular ligament of right ankle"
+            },
+            {
+              "code": "845.02",
+              "system": "urn:oid:2.16.840.1.113883.6.103",
+              "display": "Sprain of calcaneofibular ligament of right ankle"
+            },
+            {
+              "code": "1608716",
+              "system": "urn:oid:2.16.840.1.113883.3.247.1.1",
+              "display": "Sprain of calcaneofibular ligament of right ankle"
+            }
+          ]
+        },
+        "onsetDateTime": "2019-04-16",
+        "note": [
+          {
+            "text": "<content xmlns=\"urn:hl7-org:v3\">A note:</content><paragraph styleCode=\"xcellHeader\" xmlns=\"urn:hl7-org:v3\">Last Assessment &amp; Plan: </paragraph><content xmlns=\"urn:hl7-org:v3\"><content styleCode=\"xLabel\">Formatting of this note might be different from the original.</content><br />This is my note about this problem.</content><br xmlns=\"urn:hl7-org:v3\" />"
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/34728086-4b53-a5f0-8eaa-61f72b79a78c"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:b3f9a35e-828c-e0aa-f083-b95837e69a31",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "b3f9a35e-828c-e0aa-f083-b95837e69a31",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.768076",
+            "value": "35774"
+          }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "code": "55561003",
+              "system": "http://snomed.info/sct",
+              "display": "Active"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "code": "problem-item-list",
+                "display": "Problem List Item",
+                "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "code": "1003722009",
+              "system": "http://snomed.info/sct"
+            },
+            {
+              "code": "M25.569",
+              "system": "urn:oid:2.16.840.1.113883.6.90",
+              "display": "Knee pain"
+            },
+            {
+              "code": "719.46",
+              "system": "urn:oid:2.16.840.1.113883.6.103",
+              "display": "Knee pain"
+            },
+            {
+              "code": "78845",
+              "system": "urn:oid:2.16.840.1.113883.3.247.1.1",
+              "display": "Knee pain"
+            }
+          ]
+        },
+        "onsetDateTime": "2019-04-29",
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/b3f9a35e-828c-e0aa-f083-b95837e69a31"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:9e83e83e-8c39-c58f-d96c-72bb94b75531",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "9e83e83e-8c39-c58f-d96c-72bb94b75531",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.768076",
+            "value": "57636"
+          }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "code": "55561003",
+              "system": "http://snomed.info/sct",
+              "display": "Active"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "code": "problem-item-list",
+                "display": "Problem List Item",
+                "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "code": "48694002",
+              "system": "http://snomed.info/sct"
+            },
+            {
+              "code": "F41.9",
+              "system": "urn:oid:2.16.840.1.113883.6.90",
+              "display": "Anxiety"
+            },
+            {
+              "code": "300.00",
+              "system": "urn:oid:2.16.840.1.113883.6.103",
+              "display": "Anxiety"
+            },
+            {
+              "code": "38413",
+              "system": "urn:oid:2.16.840.1.113883.3.247.1.1",
+              "display": "Anxiety"
+            }
+          ]
+        },
+        "onsetDateTime": "2020-11-10",
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/9e83e83e-8c39-c58f-d96c-72bb94b75531"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:b8166f2c-ad38-da4b-aec4-974cc2c6664f",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "b8166f2c-ad38-da4b-aec4-974cc2c6664f",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.768076",
+            "value": "57637"
+          }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "code": "55561003",
+              "system": "http://snomed.info/sct",
+              "display": "Active"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "code": "problem-item-list",
+                "display": "Problem List Item",
+                "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "code": "195967001",
+              "system": "http://snomed.info/sct"
+            },
+            {
+              "code": "J45.909",
+              "system": "urn:oid:2.16.840.1.113883.6.90",
+              "display": "Asthma"
+            },
+            {
+              "code": "493.90",
+              "system": "urn:oid:2.16.840.1.113883.6.103",
+              "display": "Asthma"
+            },
+            {
+              "code": "94262",
+              "system": "urn:oid:2.16.840.1.113883.3.247.1.1",
+              "display": "Asthma"
+            }
+          ]
+        },
+        "onsetDateTime": "2020-11-10",
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/b8166f2c-ad38-da4b-aec4-974cc2c6664f"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:5dad7636-f4ae-0823-a58d-3536ce82c42b",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "5dad7636-f4ae-0823-a58d-3536ce82c42b",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.768076",
+            "value": "58351"
+          }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "code": "55561003",
+              "system": "http://snomed.info/sct",
+              "display": "Active"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "code": "problem-item-list",
+                "display": "Problem List Item",
+                "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "code": "239792003",
+              "system": "http://snomed.info/sct"
+            },
+            {
+              "code": "M06.00",
+              "system": "urn:oid:2.16.840.1.113883.6.90",
+              "display": "Rheumatoid arthritis with negative rheumatoid factor"
+            },
+            {
+              "code": "714.0",
+              "system": "urn:oid:2.16.840.1.113883.6.103",
+              "display": "Rheumatoid arthritis with negative rheumatoid factor"
+            },
+            {
+              "code": "61725782",
+              "system": "urn:oid:2.16.840.1.113883.3.247.1.1",
+              "display": "Rheumatoid arthritis with negative rheumatoid factor"
+            }
+          ]
+        },
+        "onsetDateTime": "2020-11-16",
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/5dad7636-f4ae-0823-a58d-3536ce82c42b"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:f5840e99-3485-96c0-ee31-139f1cdb7c36",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "f5840e99-3485-96c0-ee31-139f1cdb7c36",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.768076",
+            "value": "58352"
+          }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "code": "55561003",
+              "system": "http://snomed.info/sct",
+              "display": "Active"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "code": "problem-item-list",
+                "display": "Problem List Item",
+                "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "code": "12247731000119102",
+              "system": "http://snomed.info/sct"
+            },
+            {
+              "code": "M25.571",
+              "system": "urn:oid:2.16.840.1.113883.6.90",
+              "display": "Arthralgia of both ankles"
+            },
+            {
+              "code": "719.47",
+              "system": "urn:oid:2.16.840.1.113883.6.103",
+              "display": "Arthralgia of both ankles"
+            },
+            {
+              "code": "50984401",
+              "system": "urn:oid:2.16.840.1.113883.3.247.1.1",
+              "display": "Arthralgia of both ankles"
+            }
+          ]
+        },
+        "onsetDateTime": "2020-11-16",
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/f5840e99-3485-96c0-ee31-139f1cdb7c36"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:650e3ee3-148d-3895-2406-7dc0da609ae0",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "650e3ee3-148d-3895-2406-7dc0da609ae0",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.768076",
+            "value": "58701"
+          }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "code": "55561003",
+              "system": "http://snomed.info/sct",
+              "display": "Active"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "code": "problem-item-list",
+                "display": "Problem List Item",
+                "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "code": "371596008",
+              "system": "http://snomed.info/sct"
+            },
+            {
+              "code": "F31.9",
+              "system": "urn:oid:2.16.840.1.113883.6.90",
+              "display": "Bipolar I disorder"
+            },
+            {
+              "code": "296.7",
+              "system": "urn:oid:2.16.840.1.113883.6.103",
+              "display": "Bipolar I disorder"
+            },
+            {
+              "code": "700699",
+              "system": "urn:oid:2.16.840.1.113883.3.247.1.1",
+              "display": "Bipolar I disorder"
+            }
+          ]
+        },
+        "onsetDateTime": "2020-11-19",
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/650e3ee3-148d-3895-2406-7dc0da609ae0"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:e6367140-81af-9ccf-c974-c2170bc95500",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "e6367140-81af-9ccf-c974-c2170bc95500",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.768076",
+            "value": "58702"
+          }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "code": "55561003",
+              "system": "http://snomed.info/sct",
+              "display": "Active"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "code": "problem-item-list",
+                "display": "Problem List Item",
+                "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "code": "87414006",
+              "system": "http://snomed.info/sct"
+            },
+            {
+              "code": "F32.9",
+              "system": "urn:oid:2.16.840.1.113883.6.90",
+              "display": "Reactive depression"
+            },
+            {
+              "code": "300.4",
+              "system": "urn:oid:2.16.840.1.113883.6.103",
+              "display": "Reactive depression"
+            },
+            {
+              "code": "41752",
+              "system": "urn:oid:2.16.840.1.113883.3.247.1.1",
+              "display": "Reactive depression"
+            }
+          ]
+        },
+        "onsetDateTime": "2020-11-19",
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/e6367140-81af-9ccf-c974-c2170bc95500"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:823720ec-065c-cd62-9e80-9360584e52ab",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "823720ec-065c-cd62-9e80-9360584e52ab",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.798268",
+            "value": "1670844"
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "LAB10082",
+              "system": "http://www.ama-assn.org/go/cpt",
+              "display": "STOOL PATHOGENS, NAAT, 12 TO 25 TARGETS"
+            }
+          ]
+        },
+        "effectivePeriod": {
+          "start": "2022-09-28T20:51:00Z",
+          "end": "2022-09-28T20:51:00Z"
+        },
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "performer": [
+          {
+            "reference": "Organization/9e215f4e-aac1-10cb-e412-020cd13a6ad9"
+          }
+        ],
+        "result": [
+          {
+            "reference": "Observation/a00006e4-f2d8-0c10-b96b-6b56def874e1"
+          },
+          {
+            "reference": "Observation/386f91f9-9bb9-44f2-4e99-284e3d0051c8"
+          },
+          {
+            "reference": "Observation/db2ddcd3-de40-a980-701d-3295256719bb"
+          },
+          {
+            "reference": "Observation/ef277bb4-7302-f66e-0585-a90c6fe7b63f"
+          },
+          {
+            "reference": "Observation/28949844-281e-0581-70e8-38ecd287116b"
+          },
+          {
+            "reference": "Observation/38af00cb-3319-514b-3a9c-b6f71d57a6a4"
+          },
+          {
+            "reference": "Observation/9256f7d3-98ec-fce8-90d1-57aec284c887"
+          },
+          {
+            "reference": "Observation/9f4402c6-0783-bc2d-926f-3c7b96146cfd"
+          },
+          {
+            "reference": "Observation/06e693a9-b5c4-51ac-8888-086131261c46"
+          },
+          {
+            "reference": "Observation/b33d223c-9947-0795-a25d-bc0510716509"
+          },
+          {
+            "reference": "Observation/7086a08a-8e86-6354-8c0c-88d42a1c5234"
+          },
+          {
+            "reference": "Observation/d41aae21-a91a-74d8-3423-260256bc48b5"
+          },
+          {
+            "reference": "Observation/93caad24-d8f1-6b8d-82f7-7e757c5f145b"
+          },
+          {
+            "reference": "Observation/63537cc7-04fe-9788-5390-25547813e41d"
+          },
+          {
+            "reference": "Observation/23ce6d59-e5cb-a803-97d0-28e9c9ea9cf5"
+          },
+          {
+            "reference": "Observation/1bace839-10e5-14ad-eb5d-1017c1b563ed"
+          },
+          {
+            "reference": "Observation/0b6a2f7f-6ee8-c00d-8519-70ae47a94d01"
+          },
+          {
+            "reference": "Observation/993fdfcb-0d15-1ce5-7652-d9cbccd77d7f"
+          },
+          {
+            "reference": "Observation/b8746e9c-ed12-1069-1168-095692b463fb"
+          },
+          {
+            "reference": "Observation/a04992b6-9980-8866-55b9-1187c93c378c"
+          },
+          {
+            "reference": "Observation/9b963591-7fdd-96a5-69ec-1d56d9dec3a3"
+          },
+          {
+            "reference": "Observation/ad78d5cf-bae7-2456-a5c2-9a3fe45b8f8c"
+          },
+          {
+            "reference": "Observation/3d694e5a-92cc-9af5-4365-cfede30abe3c"
+          },
+          {
+            "reference": "Observation/c94403e0-3f7c-da8f-1ab0-5b426769a8aa"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "DiagnosticReport/823720ec-065c-cd62-9e80-9360584e52ab"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:9e215f4e-aac1-10cb-e412-020cd13a6ad9",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "9e215f4e-aac1-10cb-e412-020cd13a6ad9",
+        "name": "PROVIDENCE ST. JOSEPH MEDICAL CENTER LABORATORY (CLIA                                            05D0672675)",
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "501 S. Buena Vista Street"
+            ],
+            "city": "Burbank",
+            "state": "CA",
+            "postalCode": "91505"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/9e215f4e-aac1-10cb-e412-020cd13a6ad9"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:a00006e4-f2d8-0c10-b96b-6b56def874e1",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "a00006e4-f2d8-0c10-b96b-6b56def874e1",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.1"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82196-7",
+              "system": "http://loinc.org",
+              "display": "Campylobacter, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp1"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/a00006e4-f2d8-0c10-b96b-6b56def874e1"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:f35d198c-3f4c-73e3-c9a9-337f3a1f88ea",
+      "resource": {
+        "resourceType": "Device",
+        "id": "f35d198c-3f4c-73e3-c9a9-337f3a1f88ea",
+        "deviceName": [
+          {
+            "name": "LAB DEVICE: BIOFIRE® FILMARRAY® 2.0 SYSTEM"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:88e344ad-5524-27dc-5803-c49647c531bd",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "88e344ad-5524-27dc-5803-c49647c531bd",
+        "name": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+        "address": [
+          {
+            "line": [
+              "501 S. Buena Vista Street"
+            ],
+            "city": "Burbank",
+            "state": "CA",
+            "postalCode": "91505"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+1-818-847-6000"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:386f91f9-9bb9-44f2-4e99-284e3d0051c8",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "386f91f9-9bb9-44f2-4e99-284e3d0051c8",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.2"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82198-3",
+              "system": "http://loinc.org",
+              "display": "Plesiomonas shigelloides, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp2"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/386f91f9-9bb9-44f2-4e99-284e3d0051c8"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:db2ddcd3-de40-a980-701d-3295256719bb",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "db2ddcd3-de40-a980-701d-3295256719bb",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.3"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82199-1",
+              "system": "http://loinc.org",
+              "display": "Salmonella, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "260373001",
+              "system": "http://snomed.info/sct",
+              "display": "DETECTED"
+            }
+          ]
+        },
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "code": "AA",
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "display": "Abnormal Alert"
+              }
+            ]
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp3"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/db2ddcd3-de40-a980-701d-3295256719bb"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:ef277bb4-7302-f66e-0585-a90c6fe7b63f",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "ef277bb4-7302-f66e-0585-a90c6fe7b63f",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.4"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82200-7",
+              "system": "http://loinc.org",
+              "display": "Vibrio, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp4"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/ef277bb4-7302-f66e-0585-a90c6fe7b63f"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:28949844-281e-0581-70e8-38ecd287116b",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "28949844-281e-0581-70e8-38ecd287116b",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.5"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82201-5",
+              "system": "http://loinc.org",
+              "display": "Vibrio cholerae, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp5"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/28949844-281e-0581-70e8-38ecd287116b"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:38af00cb-3319-514b-3a9c-b6f71d57a6a4",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "38af00cb-3319-514b-3a9c-b6f71d57a6a4",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.6"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82202-3",
+              "system": "http://loinc.org",
+              "display": "Yersinia enterocolitica, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp6"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/38af00cb-3319-514b-3a9c-b6f71d57a6a4"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:9256f7d3-98ec-fce8-90d1-57aec284c887",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "9256f7d3-98ec-fce8-90d1-57aec284c887",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.7"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82204-9",
+              "system": "http://loinc.org",
+              "display": "E. Coli O157, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp7"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/9256f7d3-98ec-fce8-90d1-57aec284c887"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:9f4402c6-0783-bc2d-926f-3c7b96146cfd",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "9f4402c6-0783-bc2d-926f-3c7b96146cfd",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.8"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "80349-4",
+              "system": "http://loinc.org",
+              "display": "E. Coli (EAEC), NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp8"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/9f4402c6-0783-bc2d-926f-3c7b96146cfd"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:06e693a9-b5c4-51ac-8888-086131261c46",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "06e693a9-b5c4-51ac-8888-086131261c46",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.9"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "80348-6",
+              "system": "http://loinc.org",
+              "display": "E. Coli (EPEC), NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp9"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/06e693a9-b5c4-51ac-8888-086131261c46"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:b33d223c-9947-0795-a25d-bc0510716509",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "b33d223c-9947-0795-a25d-bc0510716509",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.10"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "80351-0",
+              "system": "http://loinc.org",
+              "display": "E. Coli (ETEC), NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp10"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/b33d223c-9947-0795-a25d-bc0510716509"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:7086a08a-8e86-6354-8c0c-88d42a1c5234",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "7086a08a-8e86-6354-8c0c-88d42a1c5234",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.11"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82203-1",
+              "system": "http://loinc.org",
+              "display": "Shiga-Like Toxin E. Coli (STEC), NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp11"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/7086a08a-8e86-6354-8c0c-88d42a1c5234"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:d41aae21-a91a-74d8-3423-260256bc48b5",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "d41aae21-a91a-74d8-3423-260256bc48b5",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.12"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "80350-2",
+              "system": "http://loinc.org",
+              "display": "Shigella/EIEC, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "260373001",
+              "system": "http://snomed.info/sct",
+              "display": "DETECTED"
+            }
+          ]
+        },
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "code": "AA",
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "display": "Abnormal Alert"
+              }
+            ]
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp12"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/d41aae21-a91a-74d8-3423-260256bc48b5"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:93caad24-d8f1-6b8d-82f7-7e757c5f145b",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "93caad24-d8f1-6b8d-82f7-7e757c5f145b",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.13"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82205-6",
+              "system": "http://loinc.org",
+              "display": "Cryptosporidium, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp13"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/93caad24-d8f1-6b8d-82f7-7e757c5f145b"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:63537cc7-04fe-9788-5390-25547813e41d",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "63537cc7-04fe-9788-5390-25547813e41d",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.14"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82206-4",
+              "system": "http://loinc.org",
+              "display": "Cyclospora cayetanensis, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp14"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/63537cc7-04fe-9788-5390-25547813e41d"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:23ce6d59-e5cb-a803-97d0-28e9c9ea9cf5",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "23ce6d59-e5cb-a803-97d0-28e9c9ea9cf5",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.15"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82207-2",
+              "system": "http://loinc.org",
+              "display": "E. histolytica, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp15"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/23ce6d59-e5cb-a803-97d0-28e9c9ea9cf5"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:1bace839-10e5-14ad-eb5d-1017c1b563ed",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "1bace839-10e5-14ad-eb5d-1017c1b563ed",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.16"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82208-0",
+              "system": "http://loinc.org",
+              "display": "Giardia lamblia, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp16"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/1bace839-10e5-14ad-eb5d-1017c1b563ed"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:0b6a2f7f-6ee8-c00d-8519-70ae47a94d01",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "0b6a2f7f-6ee8-c00d-8519-70ae47a94d01",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.17"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82209-8",
+              "system": "http://loinc.org",
+              "display": "Adenovirus F 40/41, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp17"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/0b6a2f7f-6ee8-c00d-8519-70ae47a94d01"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:993fdfcb-0d15-1ce5-7652-d9cbccd77d7f",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "993fdfcb-0d15-1ce5-7652-d9cbccd77d7f",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.18"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82210-6",
+              "system": "http://loinc.org",
+              "display": "Astrovirus, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp18"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/993fdfcb-0d15-1ce5-7652-d9cbccd77d7f"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:b8746e9c-ed12-1069-1168-095692b463fb",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "b8746e9c-ed12-1069-1168-095692b463fb",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.19"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82211-4",
+              "system": "http://loinc.org",
+              "display": "Norovirus, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp19"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/b8746e9c-ed12-1069-1168-095692b463fb"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:a04992b6-9980-8866-55b9-1187c93c378c",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "a04992b6-9980-8866-55b9-1187c93c378c",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.20"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82212-2",
+              "system": "http://loinc.org",
+              "display": "Rotavirus A, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp20"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/a04992b6-9980-8866-55b9-1187c93c378c"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:9b963591-7fdd-96a5-69ec-1d56d9dec3a3",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "9b963591-7fdd-96a5-69ec-1d56d9dec3a3",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.21"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82195-9",
+              "system": "http://loinc.org",
+              "display": "Sapovirus, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp21"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/9b963591-7fdd-96a5-69ec-1d56d9dec3a3"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:ad78d5cf-bae7-2456-a5c2-9a3fe45b8f8c",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "ad78d5cf-bae7-2456-a5c2-9a3fe45b8f8c",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670844.22"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "display": "GI Pathogens Panel"
+            },
+            {
+              "code": "9435",
+              "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.768282",
+              "display": "GI Pathogens Panel"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Acceptable",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp22"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/ad78d5cf-bae7-2456-a5c2-9a3fe45b8f8c"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:3d694e5a-92cc-9af5-4365-cfede30abe3c",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "3d694e5a-92cc-9af5-4365-cfede30abe3c",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.798268",
+            "value": "1670844"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "56850-1",
+              "system": "http://loinc.org",
+              "display": "Lab Interpretation"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueString": "Abnormal",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/3d694e5a-92cc-9af5-4365-cfede30abe3c"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:c94403e0-3f7c-da8f-1ab0-5b426769a8aa",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "c94403e0-3f7c-da8f-1ab0-5b426769a8aa",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.798268",
+            "value": "1670844"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "effectiveDateTime": "2022-09-28T21:00:53Z",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "18",
+              "system": "urn:oid:1.2.840.114350.1.72.1.5007"
+            }
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/c94403e0-3f7c-da8f-1ab0-5b426769a8aa"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:d4bcf569-911d-28ce-57e2-ca0c75712c48",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "d4bcf569-911d-28ce-57e2-ca0c75712c48",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.798268",
+            "value": "1670845"
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "LAB10082",
+              "system": "http://www.ama-assn.org/go/cpt",
+              "display": "STOOL PATHOGENS, NAAT, 12 TO 25 TARGETS"
+            }
+          ]
+        },
+        "effectivePeriod": {
+          "start": "2022-09-28T20:51:00Z",
+          "end": "2022-09-28T20:51:00Z"
+        },
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "performer": [
+          {
+            "reference": "Organization/9e215f4e-aac1-10cb-e412-020cd13a6ad9"
+          }
+        ],
+        "result": [
+          {
+            "reference": "Observation/57c969ce-4656-9526-8d27-e39eb8e33625"
+          },
+          {
+            "reference": "Observation/af92101a-6b5d-50b3-ebdb-45658ec25808"
+          },
+          {
+            "reference": "Observation/c0b99528-7b83-6cdb-b4af-4376e969e11d"
+          },
+          {
+            "reference": "Observation/a13fc3f5-06ed-2105-98c7-e2e0094fa1f6"
+          },
+          {
+            "reference": "Observation/f74c4591-b7a0-eceb-f8be-f1441c4bb5f1"
+          },
+          {
+            "reference": "Observation/87f76719-5e72-e3cd-cf52-5fc8635eebbd"
+          },
+          {
+            "reference": "Observation/84ba7cd9-c570-9a62-7b1f-d08b19af0973"
+          },
+          {
+            "reference": "Observation/ee4f7291-130b-ae27-8b59-60b93c8c6e1b"
+          },
+          {
+            "reference": "Observation/3351c512-bc9e-0bda-3b51-6c6f807b772d"
+          },
+          {
+            "reference": "Observation/4d20693f-fe7d-5c98-e585-a89ac8088a59"
+          },
+          {
+            "reference": "Observation/0f447d83-8760-299e-8faa-7343d4988b94"
+          },
+          {
+            "reference": "Observation/08f51019-a406-1eed-170c-297fa8cd0b68"
+          },
+          {
+            "reference": "Observation/4621b183-3bc3-6865-6f28-b0561a641270"
+          },
+          {
+            "reference": "Observation/64b0843f-a299-d049-2d18-29cd8b6de36b"
+          },
+          {
+            "reference": "Observation/c15f50f5-6285-6956-743e-4cbf10f77604"
+          },
+          {
+            "reference": "Observation/817b3760-b4a9-9265-e798-d0b2efc7150b"
+          },
+          {
+            "reference": "Observation/51864ad2-6ad4-3b11-eba3-a4ced945877c"
+          },
+          {
+            "reference": "Observation/17d1cfd4-d525-16cf-5021-b918be56fe8f"
+          },
+          {
+            "reference": "Observation/e6b1b714-4a40-5c91-8641-7e324b913652"
+          },
+          {
+            "reference": "Observation/bb8b7102-09f9-7d34-fa63-70c01d276895"
+          },
+          {
+            "reference": "Observation/a3d6cd6c-ef20-8b18-9c50-d62212af9cf0"
+          },
+          {
+            "reference": "Observation/a8147ea6-d0d8-eb95-745d-de5738a03230"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "DiagnosticReport/d4bcf569-911d-28ce-57e2-ca0c75712c48"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:57c969ce-4656-9526-8d27-e39eb8e33625",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "57c969ce-4656-9526-8d27-e39eb8e33625",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.1"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82196-7",
+              "system": "http://loinc.org",
+              "display": "Campylobacter, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp1"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/57c969ce-4656-9526-8d27-e39eb8e33625"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:af92101a-6b5d-50b3-ebdb-45658ec25808",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "af92101a-6b5d-50b3-ebdb-45658ec25808",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.2"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82198-3",
+              "system": "http://loinc.org",
+              "display": "Plesiomonas shigelloides, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp2"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/af92101a-6b5d-50b3-ebdb-45658ec25808"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:c0b99528-7b83-6cdb-b4af-4376e969e11d",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "c0b99528-7b83-6cdb-b4af-4376e969e11d",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.3"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82199-1",
+              "system": "http://loinc.org",
+              "display": "Salmonella, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp3"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/c0b99528-7b83-6cdb-b4af-4376e969e11d"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:a13fc3f5-06ed-2105-98c7-e2e0094fa1f6",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "a13fc3f5-06ed-2105-98c7-e2e0094fa1f6",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.4"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82200-7",
+              "system": "http://loinc.org",
+              "display": "Vibrio, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp4"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/a13fc3f5-06ed-2105-98c7-e2e0094fa1f6"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:f74c4591-b7a0-eceb-f8be-f1441c4bb5f1",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "f74c4591-b7a0-eceb-f8be-f1441c4bb5f1",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.5"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82201-5",
+              "system": "http://loinc.org",
+              "display": "Vibrio cholerae, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp5"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/f74c4591-b7a0-eceb-f8be-f1441c4bb5f1"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:87f76719-5e72-e3cd-cf52-5fc8635eebbd",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "87f76719-5e72-e3cd-cf52-5fc8635eebbd",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.6"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82202-3",
+              "system": "http://loinc.org",
+              "display": "Yersinia enterocolitica, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp6"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/87f76719-5e72-e3cd-cf52-5fc8635eebbd"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:84ba7cd9-c570-9a62-7b1f-d08b19af0973",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "84ba7cd9-c570-9a62-7b1f-d08b19af0973",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.7"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "80349-4",
+              "system": "http://loinc.org",
+              "display": "E. Coli (EAEC), NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp7"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/84ba7cd9-c570-9a62-7b1f-d08b19af0973"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:ee4f7291-130b-ae27-8b59-60b93c8c6e1b",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "ee4f7291-130b-ae27-8b59-60b93c8c6e1b",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.8"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "80348-6",
+              "system": "http://loinc.org",
+              "display": "E. Coli (EPEC), NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp8"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/ee4f7291-130b-ae27-8b59-60b93c8c6e1b"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:3351c512-bc9e-0bda-3b51-6c6f807b772d",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "3351c512-bc9e-0bda-3b51-6c6f807b772d",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.9"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "80351-0",
+              "system": "http://loinc.org",
+              "display": "E. Coli (ETEC), NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp9"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/3351c512-bc9e-0bda-3b51-6c6f807b772d"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:4d20693f-fe7d-5c98-e585-a89ac8088a59",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "4d20693f-fe7d-5c98-e585-a89ac8088a59",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.10"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82203-1",
+              "system": "http://loinc.org",
+              "display": "Shiga-Like Toxin E. Coli (STEC), NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp10"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/4d20693f-fe7d-5c98-e585-a89ac8088a59"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:0f447d83-8760-299e-8faa-7343d4988b94",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "0f447d83-8760-299e-8faa-7343d4988b94",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.11"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "80350-2",
+              "system": "http://loinc.org",
+              "display": "Shigella/EIEC, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp11"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/0f447d83-8760-299e-8faa-7343d4988b94"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:08f51019-a406-1eed-170c-297fa8cd0b68",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "08f51019-a406-1eed-170c-297fa8cd0b68",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.12"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82205-6",
+              "system": "http://loinc.org",
+              "display": "Cryptosporidium, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp12"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/08f51019-a406-1eed-170c-297fa8cd0b68"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:4621b183-3bc3-6865-6f28-b0561a641270",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "4621b183-3bc3-6865-6f28-b0561a641270",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.13"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82206-4",
+              "system": "http://loinc.org",
+              "display": "Cyclospora cayetanensis, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp13"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/4621b183-3bc3-6865-6f28-b0561a641270"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:64b0843f-a299-d049-2d18-29cd8b6de36b",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "64b0843f-a299-d049-2d18-29cd8b6de36b",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.14"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82207-2",
+              "system": "http://loinc.org",
+              "display": "E. histolytica, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp14"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/64b0843f-a299-d049-2d18-29cd8b6de36b"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:c15f50f5-6285-6956-743e-4cbf10f77604",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "c15f50f5-6285-6956-743e-4cbf10f77604",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.15"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82208-0",
+              "system": "http://loinc.org",
+              "display": "Giardia lamblia, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp15"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/c15f50f5-6285-6956-743e-4cbf10f77604"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:817b3760-b4a9-9265-e798-d0b2efc7150b",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "817b3760-b4a9-9265-e798-d0b2efc7150b",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.16"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82209-8",
+              "system": "http://loinc.org",
+              "display": "Adenovirus F 40/41, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp16"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/817b3760-b4a9-9265-e798-d0b2efc7150b"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:51864ad2-6ad4-3b11-eba3-a4ced945877c",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "51864ad2-6ad4-3b11-eba3-a4ced945877c",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.17"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82210-6",
+              "system": "http://loinc.org",
+              "display": "Astrovirus, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp17"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/51864ad2-6ad4-3b11-eba3-a4ced945877c"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:17d1cfd4-d525-16cf-5021-b918be56fe8f",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "17d1cfd4-d525-16cf-5021-b918be56fe8f",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.18"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82211-4",
+              "system": "http://loinc.org",
+              "display": "Norovirus, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp18"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/17d1cfd4-d525-16cf-5021-b918be56fe8f"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:e6b1b714-4a40-5c91-8641-7e324b913652",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "e6b1b714-4a40-5c91-8641-7e324b913652",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.19"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82212-2",
+              "system": "http://loinc.org",
+              "display": "Rotavirus A, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp19"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/e6b1b714-4a40-5c91-8641-7e324b913652"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:bb8b7102-09f9-7d34-fa63-70c01d276895",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "bb8b7102-09f9-7d34-fa63-70c01d276895",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.6.798268.2000",
+            "value": "1670845.20"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "82195-9",
+              "system": "http://loinc.org",
+              "display": "Sapovirus, NAAT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Not Detected",
+        "referenceRange": [
+          {
+            "text": "Not Detected"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670845.Comp20"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        },
+        "device": {
+          "reference": "Device/f35d198c-3f4c-73e3-c9a9-337f3a1f88ea"
+        },
+        "performer": [
+          {
+            "display": "PROVIDENCE ST. JOSEPH MEDICAL CENTER                                                    LABORATORY (CLIA 05D0672675)",
+            "reference": "Organization/88e344ad-5524-27dc-5803-c49647c531bd"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/bb8b7102-09f9-7d34-fa63-70c01d276895"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:a3d6cd6c-ef20-8b18-9c50-d62212af9cf0",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "a3d6cd6c-ef20-8b18-9c50-d62212af9cf0",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.798268",
+            "value": "1670845"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "56850-1",
+              "system": "http://loinc.org",
+              "display": "Lab Interpretation"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueString": "Normal",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/a3d6cd6c-ef20-8b18-9c50-d62212af9cf0"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:a8147ea6-d0d8-eb95-745d-de5738a03230",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "a8147ea6-d0d8-eb95-745d-de5738a03230",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.798268",
+            "value": "1670845"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "effectiveDateTime": "2022-09-28T20:59:43Z",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "18",
+              "system": "urn:oid:1.2.840.114350.1.72.1.5007"
+            }
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Stool"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "2022-09-28T20:51:00Z"
+              },
+              {
+                "url": "specimen receive time",
+                "valueDateTime": "2022-09-28T20:51:36Z"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/a8147ea6-d0d8-eb95-745d-de5738a03230"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:8216269f-2076-4765-26e8-f9760da7da3c",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "8216269f-2076-4765-26e8-f9760da7da3c",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.1.1040.1",
+            "value": "Z41472^^72166-2"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "72166-2",
+              "system": "http://loinc.org",
+              "display": "Tobacco smoking status NHIS"
+            }
+          ]
+        },
+        "effectiveDateTime": "2019-04-16",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "266919005",
+              "system": "http://snomed.info/sct",
+              "display": "Never smoked tobacco"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/8216269f-2076-4765-26e8-f9760da7da3c"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:70f271bc-1399-6de9-83b6-dd02ae368a16",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "70f271bc-1399-6de9-83b6-dd02ae368a16",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.1.1040.8",
+            "value": "Z41472^^713914004"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "229819007",
+              "system": "http://snomed.info/sct",
+              "display": "Tobacco use and exposure"
+            },
+            {
+              "code": "88031-0",
+              "system": "http://loinc.org",
+              "display": "Smokeless tobacco status"
+            }
+          ]
+        },
+        "effectiveDateTime": "2019-04-16",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "451381000124107",
+              "system": "http://snomed.info/sct",
+              "display": "Smokeless tobacco non-user"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/70f271bc-1399-6de9-83b6-dd02ae368a16"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:8bf22e17-362c-0c96-6cd2-8d22655b24bd",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "8bf22e17-362c-0c96-6cd2-8d22655b24bd",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.1.1040.12",
+            "value": "Z41472^55374.98^160573003"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "160573003",
+              "system": "http://snomed.info/sct",
+              "display": "Alcohol intake"
+            },
+            {
+              "code": "11331-6",
+              "system": "http://loinc.org",
+              "display": "History of Alcohol Use"
+            }
+          ]
+        },
+        "effectiveDateTime": "2022-02-16",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "219006",
+              "system": "http://snomed.info/sct",
+              "display": "Current drinker of alcohol (finding)"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/8bf22e17-362c-0c96-6cd2-8d22655b24bd"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:",
+      "resource": {
+        "resourceType": "Observation",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:7a4b0e4b-ca8a-a39b-1b44-19efe2c9ee5c",
+      "resource": {
+        "resourceType": "Immunization",
+        "id": "7a4b0e4b-ca8a-a39b-1b44-19efe2c9ee5c",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.768076",
+            "value": "35371"
+          }
+        ],
+        "occurrenceDateTime": "2010-04-16",
+        "status": "completed",
+        "primarySource": true
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Immunization/7a4b0e4b-ca8a-a39b-1b44-19efe2c9ee5c"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:b5d003f7-cfe2-56a4-6e91-07307f25aa83",
+      "resource": {
+        "resourceType": "Immunization",
+        "id": "b5d003f7-cfe2-56a4-6e91-07307f25aa83",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.768076",
+            "value": "57643"
+          }
+        ],
+        "occurrenceDateTime": "2020-11-10",
+        "vaccineCode": {
+          "coding": [
+            {
+              "code": "49281-400-10",
+              "system": "urn:oid:2.16.840.1.113883.6.69"
+            }
+          ]
+        },
+        "lotNumber": "369258741",
+        "manufacturer": {
+          "reference": "Organization/b5c77b86-2764-79f9-10bf-5da5e63eb7c1"
+        },
+        "status": "completed",
+        "primarySource": true,
+        "patient": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Immunization/b5d003f7-cfe2-56a4-6e91-07307f25aa83"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:b5c77b86-2764-79f9-10bf-5da5e63eb7c1",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "b5c77b86-2764-79f9-10bf-5da5e63eb7c1",
+        "name": "Sanofi Pasteur"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/b5c77b86-2764-79f9-10bf-5da5e63eb7c1"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:cffb2ab8-483c-a93e-56c3-5cc3d11e9168",
+      "resource": {
+        "resourceType": "Immunization",
+        "id": "cffb2ab8-483c-a93e-56c3-5cc3d11e9168",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.768076",
+            "value": "57644"
+          }
+        ],
+        "occurrenceDateTime": "2011-11-11",
+        "status": "completed",
+        "primarySource": true
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Immunization/cffb2ab8-483c-a93e-56c3-5cc3d11e9168"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:35c0d7fc-0bc0-5a24-e65e-dc30321d7e2e",
+      "resource": {
+        "resourceType": "Immunization",
+        "id": "35c0d7fc-0bc0-5a24-e65e-dc30321d7e2e",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.768076",
+            "value": "58353"
+          }
+        ],
+        "occurrenceDateTime": "2020-11-16",
+        "vaccineCode": {
+          "coding": [
+            {
+              "code": "50090-1890-1",
+              "system": "urn:oid:2.16.840.1.113883.6.69"
+            }
+          ]
+        },
+        "lotNumber": "1",
+        "manufacturer": {
+          "reference": "Organization/b5c77b86-2764-79f9-10bf-5da5e63eb7c1"
+        },
+        "status": "completed",
+        "primarySource": true,
+        "patient": {
+          "reference": "Patient/8766f0ee-be25-6c76-9a5d-e3885ffb79c1"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Immunization/35c0d7fc-0bc0-5a24-e65e-dc30321d7e2e"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:50fc36a0-b859-c4a4-de8f-53c149080081",
+      "resource": {
+        "resourceType": "Immunization",
+        "id": "50fc36a0-b859-c4a4-de8f-53c149080081",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.297.3.7.2.768076",
+            "value": "58354"
+          }
+        ],
+        "occurrenceDateTime": "1974-03-21",
+        "status": "completed",
+        "primarySource": true
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Immunization/50fc36a0-b859-c4a4-de8f-53c149080081"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fix the logic for finding the specimen source so that the order of components does not matter. Currently, if the specimen source isn't the last component, it will get wiped out by a later component. Also, make sure these variables don't leak outside of result handling and tighten the specimen extension inclusion to cases where there are a true specimen.

Add a snapshot test that covers these cases well/establish snapshot testing for eCRs.