### PR TITLE
Pull in latest from upstream, update to dotnet 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: "6.0.x"
+          dotnet-version: "8.0.x"
       - name: Run tests
         run: dotnet test --filter FullyQualifiedName~Converter.UnitTests
   
@@ -27,6 +27,6 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: "6.0.x"
+          dotnet-version: "8.0.x"
       - name: Run tests
         run: dotnet test --filter FullyQualifiedName~Converter.FunctionalTests

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
     <Product>Microsoft Health</Product>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepoRootPath>$(MSBuildThisFileDirectory)</RepoRootPath>
+	  <LatestFramework>net8.0</LatestFramework>  
   </PropertyGroup>
 
   <PropertyGroup>

--- a/build/build.yml
+++ b/build/build.yml
@@ -4,9 +4,9 @@ parameters:
 
 steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk 6.0.x'
+    displayName: 'Use .NET Core sdk 8.0.x'
     inputs:
-      version: 6.0.x
+      version: 8.0.x
       selectOrConfig: configs
       nugetConfigPath: nuget.config
 

--- a/build/publish-nugets.yml
+++ b/build/publish-nugets.yml
@@ -1,8 +1,8 @@
 steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk 6.0.x'
+    displayName: 'Use .NET Core sdk 8.0.x'
     inputs:
-      version: 6.0.x
+      version: 8.0.x
       selectOrConfig: configs
       nugetConfigPath: nuget.config
 

--- a/data/Templates/Stu3ToR4/Questionnaire/_Initial.liquid
+++ b/data/Templates/Stu3ToR4/Questionnaire/_Initial.liquid
@@ -1,7 +1,7 @@
 {
-  "valueBoolean" : {{msg.initialBoolean}},
-  "valueDecimal" : {{msg.initialDecimal}},
-  "valueInteger" : {{msg.initialInteger}},
+  "valueBoolean" : {{msg.initialBoolean | default: 'null'}},
+  "valueDecimal" : {{msg.initialDecimal | default: 'null'}},
+  "valueInteger" : {{msg.initialInteger | default: 'null'}},
   "valueDate" : "{{msg.initialDate}}",
   "valueDateTime" : "{{msg.initialDateTime}}",
   "valueTime" : "{{msg.initialTime}}",
@@ -13,4 +13,3 @@
   "valueReference" : {{msg.initialReference | to_json_string | default : '""'}},
   "initial[x]" : "",
 }
-

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests.csproj
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(LatestFramework)</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests.csproj
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Hl7.Fhir.R4" Version="2.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" NoWarn="NU1605" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Microsoft.Health.Fhir.Liquid.Converter.Tool.csproj
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Microsoft.Health.Fhir.Liquid.Converter.Tool.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Microsoft.Health.Fhir.Liquid.Converter.Tool.csproj
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Microsoft.Health.Fhir.Liquid.Converter.Tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(LatestFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
     <NuspecFile>Microsoft.Health.Fhir.Liquid.Converter.Tool.nuspec</NuspecFile>
   </PropertyGroup>

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Microsoft.Health.Fhir.Liquid.Converter.Tool.nuspec
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Microsoft.Health.Fhir.Liquid.Converter.Tool.nuspec
@@ -9,10 +9,10 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Package Description</description>
     <contentFiles>
-      <files include="any/net6.0/**/*.*" buildAction="Content" copyToOutput="true" />
+      <files include="any/net8.0/**/*.*" buildAction="Content" copyToOutput="true" />
     </contentFiles>
   </metadata>
   <files>
-    <file src="..\..\bin\publish\**" target="contentFiles\any\net6.0" />
+    <file src="..\..\bin\publish\**" target="contentFiles\any\net8.0" />
   </files>
 </package>

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SegmentFiltersTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SegmentFiltersTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
 using Microsoft.Health.Fhir.Liquid.Converter.Models.Hl7v2;
 using Microsoft.Health.Fhir.Liquid.Converter.Parsers;
 using Xunit;
@@ -45,7 +46,7 @@ RXA|0|1|20131112||88^influenza, unspecified formulation^CVX|999|||01^Historical 
             Assert.True(!segments.ContainsKey("PV1"));
 
             // Hl7v2Data and segment id content could not be null
-            Assert.Throws<NullReferenceException>(() => Filters.GetFirstSegments(null, "PID"));
+            Assert.Throws<TemplateLoadException>(() => Filters.GetFirstSegments(null, "PID"));
             Assert.Throws<NullReferenceException>(() => Filters.GetFirstSegments(new Hl7v2Data(), null));
         }
 

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Microsoft.Health.Fhir.Liquid.Converter.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Microsoft.Health.Fhir.Liquid.Converter.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(LatestFramework)</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Microsoft.Health.Fhir.Liquid.Converter.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Microsoft.Health.Fhir.Liquid.Converter.UnitTests.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" NoWarn="NU1605" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/SegmentFilters.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/SegmentFilters.cs
@@ -6,6 +6,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
+using Microsoft.Health.Fhir.Liquid.Converter.Models;
 using Microsoft.Health.Fhir.Liquid.Converter.Models.Hl7v2;
 
 namespace Microsoft.Health.Fhir.Liquid.Converter
@@ -17,6 +19,11 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
     {
         public static Dictionary<string, Hl7v2Segment> GetFirstSegments(Hl7v2Data hl7v2Data, string segmentIdContent)
         {
+            if (hl7v2Data == null)
+            {
+                throw new TemplateLoadException(FhirConverterErrorCode.TemplateDataMismatch, "Incorrect template was passed in for the input data format.");
+            }
+
             var result = new Dictionary<string, Hl7v2Segment>();
             var segmentIds = segmentIdContent.Split(@"|");
             for (var i = 0; i < hl7v2Data.Meta.Count; ++i)

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Microsoft.Health.Fhir.Liquid.Converter.csproj
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Microsoft.Health.Fhir.Liquid.Converter.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" NoWarn="NU1605" />
-    <PackageReference Include="NJsonSchema" Version="10.7.2" />
+    <PackageReference Include="NJsonSchema" Version="11.1.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
   </ItemGroup>
 

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Microsoft.Health.Fhir.Liquid.Converter.csproj
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Microsoft.Health.Fhir.Liquid.Converter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(LatestFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>annotations</Nullable>
   </PropertyGroup>

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Microsoft.Health.Fhir.Liquid.Converter.csproj
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Microsoft.Health.Fhir.Liquid.Converter.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" NoWarn="NU1605" />
     <PackageReference Include="NJsonSchema" Version="10.7.2" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Models/FhirConverterErrorCode.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Models/FhirConverterErrorCode.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Models
         InvalidCodeMapping = 1103,
         TemplateSyntaxError = 1104,
         InvalidJsonSchema = 1105,
+        TemplateDataMismatch = 1106,
 
         // DataParseException
         InputParsingError = 1201,

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Models/PartialDateTime.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Models/PartialDateTime.cs
@@ -84,7 +84,8 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Models
 
         public PartialDateTime AddSeconds(double seconds)
         {
-            DateTimeValue = DateTimeValue.AddSeconds(seconds);
+            var timespan = TimeSpan.FromSeconds(seconds);
+            DateTimeValue = DateTimeValue.Add(timespan);
             MillisecondString = null;
 
             if (Precision != DateTimePrecision.Milliseconds)

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/BaseProcessor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/BaseProcessor.cs
@@ -129,6 +129,10 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Processors
             {
                 throw;
             }
+            catch (TemplateLoadException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 Console.WriteLine("Ex: {1} StackTrace: '{0}'", Environment.StackTrace, ex);

--- a/src/Microsoft.Health.Fhir.TemplateManagement.FunctionalTests/Microsoft.Health.Fhir.TemplateManagement.FunctionalTests.csproj
+++ b/src/Microsoft.Health.Fhir.TemplateManagement.FunctionalTests/Microsoft.Health.Fhir.TemplateManagement.FunctionalTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(LatestFramework)</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Microsoft.Health.Fhir.TemplateManagement.FunctionalTests/Microsoft.Health.Fhir.TemplateManagement.FunctionalTests.csproj
+++ b/src/Microsoft.Health.Fhir.TemplateManagement.FunctionalTests/Microsoft.Health.Fhir.TemplateManagement.FunctionalTests.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="6.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.0-preview-20201020-06" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" NoWarn="NU1605" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Microsoft.Health.Fhir.TemplateManagement.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Microsoft.Health.Fhir.TemplateManagement.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(LatestFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Microsoft.Health.Fhir.TemplateManagement.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Microsoft.Health.Fhir.TemplateManagement.UnitTests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="6.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" NoWarn="NU1605" />
     <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.Liquid.Converter.nuspec
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.Liquid.Converter.nuspec
@@ -9,7 +9,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Package Description</description>
     <dependencies>
-      <group targetFramework="net6.0">
+      <group targetFramework="net8.0">
         <dependency id="Antlr4.Runtime.Standard" version="4.8.0" exclude="Build,Analyzers" />
         <dependency id="Azure.Identity" version="1.10.3" exclude="Build,Analyzers" />
         <dependency id="Azure.Storage.Blobs" version="12.17.0" exclude="Build,Analyzers" />
@@ -32,7 +32,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\Release\net6.0\Microsoft.Health.Fhir.Liquid.Converter.dll" target="lib\net6.0" />
-    <file src="bin\Release\net6.0\Microsoft.Health.Fhir.TemplateManagement.dll" target="lib\net6.0" />
+    <file src="bin\Release\net8.0\Microsoft.Health.Fhir.Liquid.Converter.dll" target="lib\net8.0" />
+    <file src="bin\Release\net8.0\Microsoft.Health.Fhir.TemplateManagement.dll" target="lib\net8.0" />
   </files>
 </package>

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.Liquid.Converter.nuspec
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.Liquid.Converter.nuspec
@@ -22,7 +22,7 @@
         <dependency id="Microsoft.Extensions.Logging" version="3.1.9" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="3.1.9" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Options" version="5.0.0" exclude="Build,Analyzers" />
-        <dependency id="Newtonsoft.Json" version="13.0.1" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
         <dependency id="NJsonSchema" version="10.7.2" exclude="Build,Analyzers" />
         <dependency id="Polly" version="7.2.4" exclude="Build,Analyzers" />
         <dependency id="SharpCompress" version="0.29.0" exclude="Build,Analyzers" />

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.Liquid.Converter.nuspec
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.Liquid.Converter.nuspec
@@ -23,7 +23,7 @@
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="3.1.9" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Options" version="5.0.0" exclude="Build,Analyzers" />
         <dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
-        <dependency id="NJsonSchema" version="10.7.2" exclude="Build,Analyzers" />
+        <dependency id="NJsonSchema" version="11.1.0" exclude="Build,Analyzers" />
         <dependency id="Polly" version="7.2.4" exclude="Build,Analyzers" />
         <dependency id="SharpCompress" version="0.29.0" exclude="Build,Analyzers" />
         <dependency id="System.Runtime" version="4.3.1" exclude="Build,Analyzers" />

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.TemplateManagement.csproj
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.TemplateManagement.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(LatestFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
     <NuspecFile>Microsoft.Health.Fhir.Liquid.Converter.nuspec</NuspecFile>
     <OrasVersion>0.12.0</OrasVersion>

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.TemplateManagement.csproj
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.TemplateManagement.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Azure.ContainerRegistry" Version="1.0.0-preview.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" NoWarn="NU1605" />
     <PackageReference Include="Polly" Version="7.2.4" />
     <PackageReference Include="SharpCompress" Version="0.29.0" />
     <PackageReference Include="System.Runtime.Caching" Version="6.0.0" />


### PR DESCRIPTION
Pull in the latest commits from the Microsoft upstream repo. This includes updating the repo to dotnet v8, which required a tiny bit more work to keep our github actions running